### PR TITLE
增加了对Swift的支持

### DIFF
--- a/Example/Logan-iOS/Logan-iOS/Base.lproj/Main.storyboard
+++ b/Example/Logan-iOS/Logan-iOS/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="whP-gf-Uak">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="whP-gf-Uak">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>

--- a/Example/Logan-iOS/Logan-iOS/LGViewController.m
+++ b/Example/Logan-iOS/Logan-iOS/LGViewController.m
@@ -72,8 +72,8 @@ typedef enum : NSUInteger {
 }
 
 - (IBAction)uploadFile:(id)sender {
-    loganUploadFilePath(loganTodaysDate(), ^(NSString *_Nullable filePatch) {
-        if (filePatch == nil) {
+    loganUploadFilePath(loganTodaysDate(), ^(NSString *_Nullable filePath) {
+        if (filePath == nil) {
             return;
         }
         NSString *urlStr = [NSString stringWithFormat:@"http://%@:3000/logupload", self.ipText.text ?: @"127.0.0.1"];
@@ -81,7 +81,7 @@ typedef enum : NSUInteger {
         NSMutableURLRequest *req = [[NSMutableURLRequest alloc] initWithURL:url cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:60];
         [req setHTTPMethod:@"POST"];
         [req addValue:@"binary/octet-stream" forHTTPHeaderField:@"Content-Type"];
-        NSURL *fileUrl = [NSURL fileURLWithPath:filePatch];
+        NSURL *fileUrl = [NSURL fileURLWithPath:filePath];
         NSURLSessionUploadTask *task = [[NSURLSession sharedSession] uploadTaskWithRequest:req fromFile:fileUrl completionHandler:^(NSData *_Nullable data, NSURLResponse *_Nullable response, NSError *_Nullable error) {
             if (error == nil) {
                 NSLog(@"上传完成");

--- a/Example/Logan-iOS/Tests/LoganTests.m
+++ b/Example/Logan-iOS/Tests/LoganTests.m
@@ -64,8 +64,8 @@
 }
 
 - (void)testUploadFilePath {
-    loganUploadFilePath(loganTodaysDate(), ^(NSString *_Nullable filePatch) {
-        XCTAssertNotNil(filePatch, @"file patch should not be nil");
+    loganUploadFilePath(loganTodaysDate(), ^(NSString *_Nullable filePath) {
+        XCTAssertNotNil(filePath, @"file path should not be nil");
     });
 }
 

--- a/Example/LoganSwift/LoganSwift.xcodeproj/project.pbxproj
+++ b/Example/LoganSwift/LoganSwift.xcodeproj/project.pbxproj
@@ -180,6 +180,11 @@
 		028F97A021E3826400B1DF4C /* pk_wrap.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210521E0EF4D00E023B9 /* pk_wrap.c */; };
 		028F97A121E3826400B1DF4C /* md4.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210221E0EF4D00E023B9 /* md4.c */; };
 		028F97A221E3826400B1DF4C /* havege.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211D21E0EF4D00E023B9 /* havege.c */; };
+		028F97B321E3893000B1DF4C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028F97B221E3893000B1DF4C /* AppDelegate.swift */; };
+		028F97B521E3893100B1DF4C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 028F97B421E3893100B1DF4C /* Assets.xcassets */; };
+		028F97B821E3893100B1DF4C /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 028F97B621E3893100B1DF4C /* MainMenu.xib */; };
+		028F97BE21E3894C00B1DF4C /* LoganSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 028F97A821E3826400B1DF4C /* LoganSwift.framework */; };
+		028F97BF21E3897700B1DF4C /* LoganExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026DC45521E329FB00163479 /* LoganExtension.swift */; };
 		02BD1F5221E0BCBB00E023B9 /* LoganSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD1F5021E0BCBB00E023B9 /* LoganSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		02BD20B221E0E6A400E023B9 /* LoganSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BD20B121E0E6A400E023B9 /* LoganSwift.swift */; };
 		02BD216321E0EF4E00E023B9 /* pem.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20B721E0EF4D00E023B9 /* pem.h */; };
@@ -358,6 +363,12 @@
 		026DC45121E3299900163479 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		026DC45521E329FB00163479 /* LoganExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoganExtension.swift; sourceTree = "<group>"; };
 		028F97A821E3826400B1DF4C /* LoganSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LoganSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		028F97B021E3893000B1DF4C /* example macOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "example macOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		028F97B221E3893000B1DF4C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		028F97B421E3893100B1DF4C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		028F97B721E3893100B1DF4C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
+		028F97B921E3893100B1DF4C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		028F97BA21E3893100B1DF4C /* example_macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = example_macOS.entitlements; sourceTree = "<group>"; };
 		02BD1F4D21E0BCBB00E023B9 /* LoganSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LoganSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		02BD1F5021E0BCBB00E023B9 /* LoganSwift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LoganSwift.h; sourceTree = "<group>"; };
 		02BD1F5121E0BCBB00E023B9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -550,6 +561,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		028F97AD21E3893000B1DF4C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				028F97BE21E3894C00B1DF4C /* LoganSwift.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		02BD1F4A21E0BCBB00E023B9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -581,6 +600,18 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		028F97B121E3893000B1DF4C /* example macOS */ = {
+			isa = PBXGroup;
+			children = (
+				028F97B221E3893000B1DF4C /* AppDelegate.swift */,
+				028F97B421E3893100B1DF4C /* Assets.xcassets */,
+				028F97B621E3893100B1DF4C /* MainMenu.xib */,
+				028F97B921E3893100B1DF4C /* Info.plist */,
+				028F97BA21E3893100B1DF4C /* example_macOS.entitlements */,
+			);
+			path = "example macOS";
+			sourceTree = "<group>";
+		};
 		02BD1F4321E0BCBB00E023B9 = {
 			isa = PBXGroup;
 			children = (
@@ -588,6 +619,7 @@
 				02BD20B321E0EF4D00E023B9 /* mbedtls */,
 				02BD1F4F21E0BCBB00E023B9 /* LoganSwift */,
 				026DC44421E3299800163479 /* example */,
+				028F97B121E3893000B1DF4C /* example macOS */,
 				02BD1F4E21E0BCBB00E023B9 /* Products */,
 				028F962421E33E9A00B1DF4C /* Frameworks */,
 			);
@@ -599,6 +631,7 @@
 				02BD1F4D21E0BCBB00E023B9 /* LoganSwift.framework */,
 				026DC44321E3299800163479 /* example.app */,
 				028F97A821E3826400B1DF4C /* LoganSwift.framework */,
+				028F97B021E3893000B1DF4C /* example macOS.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1044,6 +1077,23 @@
 			productReference = 028F97A821E3826400B1DF4C /* LoganSwift.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		028F97AF21E3893000B1DF4C /* example macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 028F97BB21E3893100B1DF4C /* Build configuration list for PBXNativeTarget "example macOS" */;
+			buildPhases = (
+				028F97AC21E3893000B1DF4C /* Sources */,
+				028F97AD21E3893000B1DF4C /* Frameworks */,
+				028F97AE21E3893000B1DF4C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "example macOS";
+			productName = "example macOS";
+			productReference = 028F97B021E3893000B1DF4C /* example macOS.app */;
+			productType = "com.apple.product-type.application";
+		};
 		02BD1F4C21E0BCBB00E023B9 /* LoganSwift */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 02BD1F5521E0BCBB00E023B9 /* Build configuration list for PBXNativeTarget "LoganSwift" */;
@@ -1075,6 +1125,9 @@
 					026DC44221E3299800163479 = {
 						CreatedOnToolsVersion = 10.1;
 					};
+					028F97AF21E3893000B1DF4C = {
+						CreatedOnToolsVersion = 10.1;
+					};
 					02BD1F4C21E0BCBB00E023B9 = {
 						CreatedOnToolsVersion = 10.1;
 						LastSwiftMigration = 1010;
@@ -1097,6 +1150,7 @@
 				02BD1F4C21E0BCBB00E023B9 /* LoganSwift */,
 				028F96FA21E3826400B1DF4C /* LoganSwift macOS */,
 				026DC44221E3299800163479 /* example */,
+				028F97AF21E3893000B1DF4C /* example macOS */,
 			);
 		};
 /* End PBXProject section */
@@ -1116,6 +1170,15 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		028F97AE21E3893000B1DF4C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				028F97B521E3893100B1DF4C /* Assets.xcassets in Resources */,
+				028F97B821E3893100B1DF4C /* MainMenu.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1229,6 +1292,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		028F97AC21E3893000B1DF4C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				028F97B321E3893000B1DF4C /* AppDelegate.swift in Sources */,
+				028F97BF21E3897700B1DF4C /* LoganExtension.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		02BD1F4921E0BCBB00E023B9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1338,6 +1410,14 @@
 			name = LaunchScreen.storyboard;
 			sourceTree = "<group>";
 		};
+		028F97B621E3893100B1DF4C /* MainMenu.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				028F97B721E3893100B1DF4C /* Base */,
+			);
+			name = MainMenu.xib;
+			sourceTree = "<group>";
+		};
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
@@ -1439,6 +1519,48 @@
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "i386 x86_64";
+			};
+			name = Release;
+		};
+		028F97BC21E3893100B1DF4C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = "example macOS/example_macOS.entitlements";
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = "example macOS/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.hanguang.app.example-macOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 4.2;
+			};
+			name = Debug;
+		};
+		028F97BD21E3893100B1DF4C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = "example macOS/example_macOS.entitlements";
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = "example macOS/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.hanguang.app.example-macOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -1640,6 +1762,15 @@
 			buildConfigurations = (
 				028F97A621E3826400B1DF4C /* Debug */,
 				028F97A721E3826400B1DF4C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		028F97BB21E3893100B1DF4C /* Build configuration list for PBXNativeTarget "example macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				028F97BC21E3893100B1DF4C /* Debug */,
+				028F97BD21E3893100B1DF4C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/LoganSwift/LoganSwift.xcodeproj/project.pbxproj
+++ b/Example/LoganSwift/LoganSwift.xcodeproj/project.pbxproj
@@ -7,6 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		026DC44621E3299800163479 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026DC44521E3299800163479 /* AppDelegate.swift */; };
+		026DC44821E3299800163479 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026DC44721E3299800163479 /* ViewController.swift */; };
+		026DC44B21E3299800163479 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 026DC44921E3299800163479 /* Main.storyboard */; };
+		026DC44D21E3299900163479 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 026DC44C21E3299900163479 /* Assets.xcassets */; };
+		026DC45021E3299900163479 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 026DC44E21E3299900163479 /* LaunchScreen.storyboard */; };
+		026DC45621E329FB00163479 /* LoganExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026DC45521E329FB00163479 /* LoganExtension.swift */; };
+		028F962521E33E9A00B1DF4C /* LoganSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02BD1F4D21E0BCBB00E023B9 /* LoganSwift.framework */; };
 		02BD1F5221E0BCBB00E023B9 /* LoganSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD1F5021E0BCBB00E023B9 /* LoganSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		02BD20B221E0E6A400E023B9 /* LoganSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BD20B121E0E6A400E023B9 /* LoganSwift.swift */; };
 		02BD216321E0EF4E00E023B9 /* pem.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20B721E0EF4D00E023B9 /* pem.h */; };
@@ -176,6 +183,14 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		026DC44321E3299800163479 /* example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = example.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		026DC44521E3299800163479 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		026DC44721E3299800163479 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		026DC44A21E3299800163479 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		026DC44C21E3299900163479 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		026DC44F21E3299900163479 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		026DC45121E3299900163479 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		026DC45521E329FB00163479 /* LoganExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoganExtension.swift; sourceTree = "<group>"; };
 		02BD1F4D21E0BCBB00E023B9 /* LoganSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LoganSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		02BD1F5021E0BCBB00E023B9 /* LoganSwift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LoganSwift.h; sourceTree = "<group>"; };
 		02BD1F5121E0BCBB00E023B9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -353,6 +368,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		026DC44021E3299800163479 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				028F962521E33E9A00B1DF4C /* LoganSwift.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		02BD1F4A21E0BCBB00E023B9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -363,13 +386,36 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		026DC44421E3299800163479 /* example */ = {
+			isa = PBXGroup;
+			children = (
+				026DC44521E3299800163479 /* AppDelegate.swift */,
+				026DC44721E3299800163479 /* ViewController.swift */,
+				026DC45521E329FB00163479 /* LoganExtension.swift */,
+				026DC44921E3299800163479 /* Main.storyboard */,
+				026DC44C21E3299900163479 /* Assets.xcassets */,
+				026DC44E21E3299900163479 /* LaunchScreen.storyboard */,
+				026DC45121E3299900163479 /* Info.plist */,
+			);
+			path = example;
+			sourceTree = "<group>";
+		};
+		028F962421E33E9A00B1DF4C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		02BD1F4321E0BCBB00E023B9 = {
 			isa = PBXGroup;
 			children = (
 				02BD214921E0EF4D00E023B9 /* Clogan */,
 				02BD20B321E0EF4D00E023B9 /* mbedtls */,
 				02BD1F4F21E0BCBB00E023B9 /* LoganSwift */,
+				026DC44421E3299800163479 /* example */,
 				02BD1F4E21E0BCBB00E023B9 /* Products */,
+				028F962421E33E9A00B1DF4C /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -377,6 +423,7 @@
 			isa = PBXGroup;
 			children = (
 				02BD1F4D21E0BCBB00E023B9 /* LoganSwift.framework */,
+				026DC44321E3299800163479 /* example.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -697,6 +744,23 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		026DC44221E3299800163479 /* example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 026DC45421E3299900163479 /* Build configuration list for PBXNativeTarget "example" */;
+			buildPhases = (
+				026DC43F21E3299800163479 /* Sources */,
+				026DC44021E3299800163479 /* Frameworks */,
+				026DC44121E3299800163479 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = example;
+			productName = example;
+			productReference = 026DC44321E3299800163479 /* example.app */;
+			productType = "com.apple.product-type.application";
+		};
 		02BD1F4C21E0BCBB00E023B9 /* LoganSwift */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 02BD1F5521E0BCBB00E023B9 /* Build configuration list for PBXNativeTarget "LoganSwift" */;
@@ -721,9 +785,13 @@
 		02BD1F4421E0BCBB00E023B9 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 1010;
 				LastUpgradeCheck = 1010;
 				ORGANIZATIONNAME = hanguang;
 				TargetAttributes = {
+					026DC44221E3299800163479 = {
+						CreatedOnToolsVersion = 10.1;
+					};
 					02BD1F4C21E0BCBB00E023B9 = {
 						CreatedOnToolsVersion = 10.1;
 						LastSwiftMigration = 1010;
@@ -736,6 +804,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 02BD1F4321E0BCBB00E023B9;
 			productRefGroup = 02BD1F4E21E0BCBB00E023B9 /* Products */;
@@ -743,11 +812,22 @@
 			projectRoot = "";
 			targets = (
 				02BD1F4C21E0BCBB00E023B9 /* LoganSwift */,
+				026DC44221E3299800163479 /* example */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		026DC44121E3299800163479 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				026DC45021E3299900163479 /* LaunchScreen.storyboard in Resources */,
+				026DC44D21E3299900163479 /* Assets.xcassets in Resources */,
+				026DC44B21E3299800163479 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		02BD1F4B21E0BCBB00E023B9 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -758,6 +838,16 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		026DC43F21E3299800163479 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				026DC45621E329FB00163479 /* LoganExtension.swift in Sources */,
+				026DC44821E3299800163479 /* ViewController.swift in Sources */,
+				026DC44621E3299800163479 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		02BD1F4921E0BCBB00E023B9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -850,7 +940,60 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXVariantGroup section */
+		026DC44921E3299800163479 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				026DC44A21E3299800163479 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		026DC44E21E3299900163479 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				026DC44F21E3299900163479 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
 /* Begin XCBuildConfiguration section */
+		026DC45221E3299900163479 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = example/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.hanguang.app.example;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		026DC45321E3299900163479 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = example/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.hanguang.app.example;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		02BD1F5321E0BCBB00E023B9 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -987,6 +1130,7 @@
 				HEADER_SEARCH_PATHS = ../../Logan/mbedtls/include/;
 				INFOPLIST_FILE = LoganSwift/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1016,6 +1160,7 @@
 				HEADER_SEARCH_PATHS = ../../Logan/mbedtls/include/;
 				INFOPLIST_FILE = LoganSwift/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1033,6 +1178,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		026DC45421E3299900163479 /* Build configuration list for PBXNativeTarget "example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				026DC45221E3299900163479 /* Debug */,
+				026DC45321E3299900163479 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		02BD1F4721E0BCBB00E023B9 /* Build configuration list for PBXProject "LoganSwift" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Example/LoganSwift/LoganSwift.xcodeproj/project.pbxproj
+++ b/Example/LoganSwift/LoganSwift.xcodeproj/project.pbxproj
@@ -1,0 +1,1057 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		02BD1F5221E0BCBB00E023B9 /* LoganSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD1F5021E0BCBB00E023B9 /* LoganSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		02BD20B221E0E6A400E023B9 /* LoganSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BD20B121E0E6A400E023B9 /* LoganSwift.swift */; };
+		02BD216321E0EF4E00E023B9 /* pem.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20B721E0EF4D00E023B9 /* pem.h */; };
+		02BD216421E0EF4E00E023B9 /* check_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20B821E0EF4D00E023B9 /* check_config.h */; };
+		02BD216521E0EF4E00E023B9 /* error.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20B921E0EF4D00E023B9 /* error.h */; };
+		02BD216621E0EF4E00E023B9 /* md2.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20BA21E0EF4D00E023B9 /* md2.h */; };
+		02BD216721E0EF4E00E023B9 /* oid.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20BB21E0EF4D00E023B9 /* oid.h */; };
+		02BD216821E0EF4E00E023B9 /* pkcs5.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20BC21E0EF4D00E023B9 /* pkcs5.h */; };
+		02BD216921E0EF4E00E023B9 /* ripemd160.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20BD21E0EF4D00E023B9 /* ripemd160.h */; };
+		02BD216A21E0EF4E00E023B9 /* blowfish.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20BE21E0EF4D00E023B9 /* blowfish.h */; };
+		02BD216B21E0EF4E00E023B9 /* debug.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20BF21E0EF4D00E023B9 /* debug.h */; };
+		02BD216C21E0EF4E00E023B9 /* x509.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20C021E0EF4D00E023B9 /* x509.h */; };
+		02BD216D21E0EF4E00E023B9 /* version.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20C121E0EF4D00E023B9 /* version.h */; };
+		02BD216E21E0EF4E00E023B9 /* ecp.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20C221E0EF4D00E023B9 /* ecp.h */; };
+		02BD216F21E0EF4E00E023B9 /* net.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20C321E0EF4D00E023B9 /* net.h */; };
+		02BD217021E0EF4E00E023B9 /* cipher_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20C421E0EF4D00E023B9 /* cipher_internal.h */; };
+		02BD217121E0EF4E00E023B9 /* md_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20C521E0EF4D00E023B9 /* md_internal.h */; };
+		02BD217221E0EF4E00E023B9 /* base64.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20C621E0EF4D00E023B9 /* base64.h */; };
+		02BD217321E0EF4E00E023B9 /* pkcs11.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20C721E0EF4D00E023B9 /* pkcs11.h */; };
+		02BD217421E0EF4E00E023B9 /* ssl_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20C821E0EF4D00E023B9 /* ssl_internal.h */; };
+		02BD217521E0EF4E00E023B9 /* asn1.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20C921E0EF4D00E023B9 /* asn1.h */; };
+		02BD217621E0EF4E00E023B9 /* config.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20CA21E0EF4D00E023B9 /* config.h */; };
+		02BD217721E0EF4E00E023B9 /* memory_buffer_alloc.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20CB21E0EF4D00E023B9 /* memory_buffer_alloc.h */; };
+		02BD217821E0EF4E00E023B9 /* x509_csr.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20CC21E0EF4D00E023B9 /* x509_csr.h */; };
+		02BD217921E0EF4E00E023B9 /* xtea.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20CD21E0EF4D00E023B9 /* xtea.h */; };
+		02BD217A21E0EF4E00E023B9 /* threading.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20CE21E0EF4D00E023B9 /* threading.h */; };
+		02BD217B21E0EF4E00E023B9 /* compat-1.3.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20CF21E0EF4D00E023B9 /* compat-1.3.h */; };
+		02BD217C21E0EF4E00E023B9 /* md5.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20D021E0EF4D00E023B9 /* md5.h */; };
+		02BD217D21E0EF4E00E023B9 /* timing.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20D121E0EF4D00E023B9 /* timing.h */; };
+		02BD217E21E0EF4E00E023B9 /* arc4.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20D221E0EF4D00E023B9 /* arc4.h */; };
+		02BD217F21E0EF4E00E023B9 /* sha256.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20D321E0EF4D00E023B9 /* sha256.h */; };
+		02BD218021E0EF4E00E023B9 /* ecdsa.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20D421E0EF4D00E023B9 /* ecdsa.h */; };
+		02BD218121E0EF4E00E023B9 /* md.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20D521E0EF4D00E023B9 /* md.h */; };
+		02BD218221E0EF4E00E023B9 /* cipher.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20D621E0EF4D00E023B9 /* cipher.h */; };
+		02BD218321E0EF4E00E023B9 /* ecjpake.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20D721E0EF4D00E023B9 /* ecjpake.h */; };
+		02BD218421E0EF4E00E023B9 /* net_sockets.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20D821E0EF4D00E023B9 /* net_sockets.h */; };
+		02BD218521E0EF4E00E023B9 /* entropy.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20D921E0EF4D00E023B9 /* entropy.h */; };
+		02BD218621E0EF4E00E023B9 /* pkcs12.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20DA21E0EF4D00E023B9 /* pkcs12.h */; };
+		02BD218721E0EF4E00E023B9 /* padlock.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20DB21E0EF4D00E023B9 /* padlock.h */; };
+		02BD218821E0EF4E00E023B9 /* sha512.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20DC21E0EF4D00E023B9 /* sha512.h */; };
+		02BD218921E0EF4E00E023B9 /* bn_mul.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20DD21E0EF4D00E023B9 /* bn_mul.h */; };
+		02BD218A21E0EF4E00E023B9 /* pk.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20DE21E0EF4D00E023B9 /* pk.h */; };
+		02BD218B21E0EF4E00E023B9 /* ecp_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20DF21E0EF4D00E023B9 /* ecp_internal.h */; };
+		02BD218C21E0EF4E00E023B9 /* ssl.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20E021E0EF4D00E023B9 /* ssl.h */; };
+		02BD218D21E0EF4E00E023B9 /* platform_time.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20E121E0EF4D00E023B9 /* platform_time.h */; };
+		02BD218E21E0EF4E00E023B9 /* camellia.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20E221E0EF4D00E023B9 /* camellia.h */; };
+		02BD218F21E0EF4E00E023B9 /* md4.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20E321E0EF4D00E023B9 /* md4.h */; };
+		02BD219021E0EF4E00E023B9 /* x509_crt.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20E421E0EF4D00E023B9 /* x509_crt.h */; };
+		02BD219121E0EF4E00E023B9 /* aes.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20E521E0EF4D00E023B9 /* aes.h */; };
+		02BD219221E0EF4E00E023B9 /* pk_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20E621E0EF4D00E023B9 /* pk_internal.h */; };
+		02BD219321E0EF4E00E023B9 /* ssl_cookie.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20E721E0EF4D00E023B9 /* ssl_cookie.h */; };
+		02BD219421E0EF4E00E023B9 /* dhm.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20E821E0EF4D00E023B9 /* dhm.h */; };
+		02BD219521E0EF4E00E023B9 /* aesni.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20E921E0EF4D00E023B9 /* aesni.h */; };
+		02BD219621E0EF4E00E023B9 /* ctr_drbg.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20EA21E0EF4D00E023B9 /* ctr_drbg.h */; };
+		02BD219721E0EF4E00E023B9 /* des.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20EB21E0EF4D00E023B9 /* des.h */; };
+		02BD219821E0EF4E00E023B9 /* x509_crl.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20EC21E0EF4D00E023B9 /* x509_crl.h */; };
+		02BD219921E0EF4E00E023B9 /* ecdh.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20ED21E0EF4D00E023B9 /* ecdh.h */; };
+		02BD219A21E0EF4E00E023B9 /* sha1.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20EE21E0EF4D00E023B9 /* sha1.h */; };
+		02BD219B21E0EF4E00E023B9 /* gcm.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20EF21E0EF4D00E023B9 /* gcm.h */; };
+		02BD219C21E0EF4E00E023B9 /* certs.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20F021E0EF4D00E023B9 /* certs.h */; };
+		02BD219D21E0EF4E00E023B9 /* rsa.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20F121E0EF4D00E023B9 /* rsa.h */; };
+		02BD219E21E0EF4E00E023B9 /* hmac_drbg.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20F221E0EF4D00E023B9 /* hmac_drbg.h */; };
+		02BD219F21E0EF4E00E023B9 /* ssl_ticket.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20F321E0EF4D00E023B9 /* ssl_ticket.h */; };
+		02BD21A021E0EF4E00E023B9 /* ssl_ciphersuites.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20F421E0EF4D00E023B9 /* ssl_ciphersuites.h */; };
+		02BD21A121E0EF4E00E023B9 /* ssl_cache.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20F521E0EF4D00E023B9 /* ssl_cache.h */; };
+		02BD21A221E0EF4E00E023B9 /* cmac.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20F621E0EF4D00E023B9 /* cmac.h */; };
+		02BD21A321E0EF4E00E023B9 /* platform.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20F721E0EF4D00E023B9 /* platform.h */; };
+		02BD21A421E0EF4E00E023B9 /* bignum.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20F821E0EF4D00E023B9 /* bignum.h */; };
+		02BD21A521E0EF4E00E023B9 /* entropy_poll.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20F921E0EF4D00E023B9 /* entropy_poll.h */; };
+		02BD21A621E0EF4E00E023B9 /* havege.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20FA21E0EF4D00E023B9 /* havege.h */; };
+		02BD21A721E0EF4E00E023B9 /* asn1write.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20FB21E0EF4D00E023B9 /* asn1write.h */; };
+		02BD21A821E0EF4E00E023B9 /* ccm.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20FC21E0EF4D00E023B9 /* ccm.h */; };
+		02BD21AA21E0EF4E00E023B9 /* x509_create.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD20FF21E0EF4D00E023B9 /* x509_create.c */; };
+		02BD21AB21E0EF4E00E023B9 /* x509_crt.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210021E0EF4D00E023B9 /* x509_crt.c */; };
+		02BD21AC21E0EF4E00E023B9 /* aes.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210121E0EF4D00E023B9 /* aes.c */; };
+		02BD21AD21E0EF4E00E023B9 /* md4.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210221E0EF4D00E023B9 /* md4.c */; };
+		02BD21AE21E0EF4E00E023B9 /* ssl_srv.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210321E0EF4D00E023B9 /* ssl_srv.c */; };
+		02BD21AF21E0EF4E00E023B9 /* camellia.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210421E0EF4D00E023B9 /* camellia.c */; };
+		02BD21B021E0EF4E00E023B9 /* pk_wrap.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210521E0EF4D00E023B9 /* pk_wrap.c */; };
+		02BD21B121E0EF4E00E023B9 /* pk.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210621E0EF4D00E023B9 /* pk.c */; };
+		02BD21B321E0EF4E00E023B9 /* ecdh.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210821E0EF4D00E023B9 /* ecdh.c */; };
+		02BD21B421E0EF4E00E023B9 /* ssl_tls.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210921E0EF4D00E023B9 /* ssl_tls.c */; };
+		02BD21B521E0EF4E00E023B9 /* x509_crl.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210A21E0EF4D00E023B9 /* x509_crl.c */; };
+		02BD21B621E0EF4E00E023B9 /* cipher_wrap.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210B21E0EF4D00E023B9 /* cipher_wrap.c */; };
+		02BD21B721E0EF4E00E023B9 /* des.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210C21E0EF4D00E023B9 /* des.c */; };
+		02BD21B821E0EF4E00E023B9 /* ssl_cookie.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210D21E0EF4D00E023B9 /* ssl_cookie.c */; };
+		02BD21B921E0EF4E00E023B9 /* ctr_drbg.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210E21E0EF4D00E023B9 /* ctr_drbg.c */; };
+		02BD21BA21E0EF4E00E023B9 /* aesni.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210F21E0EF4D00E023B9 /* aesni.c */; };
+		02BD21BB21E0EF4E00E023B9 /* dhm.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211021E0EF4D00E023B9 /* dhm.c */; };
+		02BD21BC21E0EF4E00E023B9 /* ssl_cache.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211121E0EF4D00E023B9 /* ssl_cache.c */; };
+		02BD21BD21E0EF4E00E023B9 /* ssl_ciphersuites.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211221E0EF4D00E023B9 /* ssl_ciphersuites.c */; };
+		02BD21BE21E0EF4E00E023B9 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211321E0EF4D00E023B9 /* Makefile */; };
+		02BD21BF21E0EF4E00E023B9 /* hmac_drbg.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211421E0EF4D00E023B9 /* hmac_drbg.c */; };
+		02BD21C021E0EF4E00E023B9 /* rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211521E0EF4D00E023B9 /* rsa.c */; };
+		02BD21C121E0EF4E00E023B9 /* ssl_ticket.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211621E0EF4D00E023B9 /* ssl_ticket.c */; };
+		02BD21C221E0EF4E00E023B9 /* asn1parse.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211721E0EF4D00E023B9 /* asn1parse.c */; };
+		02BD21C321E0EF4E00E023B9 /* certs.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211821E0EF4D00E023B9 /* certs.c */; };
+		02BD21C421E0EF4E00E023B9 /* pkwrite.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211921E0EF4D00E023B9 /* pkwrite.c */; };
+		02BD21C521E0EF4E00E023B9 /* gcm.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211A21E0EF4D00E023B9 /* gcm.c */; };
+		02BD21C621E0EF4E00E023B9 /* sha1.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211B21E0EF4D00E023B9 /* sha1.c */; };
+		02BD21C721E0EF4E00E023B9 /* asn1write.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211C21E0EF4D00E023B9 /* asn1write.c */; };
+		02BD21C821E0EF4E00E023B9 /* havege.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211D21E0EF4D00E023B9 /* havege.c */; };
+		02BD21C921E0EF4E00E023B9 /* ccm.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211E21E0EF4D00E023B9 /* ccm.c */; };
+		02BD21CA21E0EF4E00E023B9 /* version_features.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211F21E0EF4D00E023B9 /* version_features.c */; };
+		02BD21CB21E0EF4E00E023B9 /* entropy_poll.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212021E0EF4D00E023B9 /* entropy_poll.c */; };
+		02BD21CC21E0EF4E00E023B9 /* x509write_csr.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212121E0EF4D00E023B9 /* x509write_csr.c */; };
+		02BD21CD21E0EF4E00E023B9 /* platform.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212221E0EF4D00E023B9 /* platform.c */; };
+		02BD21CE21E0EF4E00E023B9 /* cmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212321E0EF4D00E023B9 /* cmac.c */; };
+		02BD21CF21E0EF4E00E023B9 /* bignum.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212421E0EF4D00E023B9 /* bignum.c */; };
+		02BD21D021E0EF4E00E023B9 /* pkparse.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212521E0EF4D00E023B9 /* pkparse.c */; };
+		02BD21D121E0EF4E00E023B9 /* debug.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212621E0EF4D00E023B9 /* debug.c */; };
+		02BD21D221E0EF4E00E023B9 /* ripemd160.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212721E0EF4D00E023B9 /* ripemd160.c */; };
+		02BD21D321E0EF4E00E023B9 /* ssl_cli.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212821E0EF4D00E023B9 /* ssl_cli.c */; };
+		02BD21D421E0EF4E00E023B9 /* blowfish.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212921E0EF4D00E023B9 /* blowfish.c */; };
+		02BD21D521E0EF4E00E023B9 /* pkcs5.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212A21E0EF4D00E023B9 /* pkcs5.c */; };
+		02BD21D621E0EF4E00E023B9 /* pem.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212B21E0EF4D00E023B9 /* pem.c */; };
+		02BD21D821E0EF4E00E023B9 /* oid.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212D21E0EF4D00E023B9 /* oid.c */; };
+		02BD21D921E0EF4E00E023B9 /* error.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212E21E0EF4D00E023B9 /* error.c */; };
+		02BD21DA21E0EF4E00E023B9 /* md2.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212F21E0EF4D00E023B9 /* md2.c */; };
+		02BD21DB21E0EF4E00E023B9 /* md_wrap.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213021E0EF4D00E023B9 /* md_wrap.c */; };
+		02BD21DC21E0EF4E00E023B9 /* x509_csr.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213121E0EF4D00E023B9 /* x509_csr.c */; };
+		02BD21DD21E0EF4E00E023B9 /* pkcs11.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213221E0EF4D00E023B9 /* pkcs11.c */; };
+		02BD21DE21E0EF4E00E023B9 /* base64.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213321E0EF4D00E023B9 /* base64.c */; };
+		02BD21DF21E0EF4E00E023B9 /* memory_buffer_alloc.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213421E0EF4D00E023B9 /* memory_buffer_alloc.c */; };
+		02BD21E021E0EF4E00E023B9 /* ecp.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213521E0EF4D00E023B9 /* ecp.c */; };
+		02BD21E121E0EF4E00E023B9 /* version.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213621E0EF4D00E023B9 /* version.c */; };
+		02BD21E221E0EF4E00E023B9 /* x509.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213721E0EF4D00E023B9 /* x509.c */; };
+		02BD21E321E0EF4E00E023B9 /* sha256.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213821E0EF4D00E023B9 /* sha256.c */; };
+		02BD21E421E0EF4E00E023B9 /* ecp_curves.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213921E0EF4D00E023B9 /* ecp_curves.c */; };
+		02BD21E521E0EF4E00E023B9 /* md5.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213A21E0EF4D00E023B9 /* md5.c */; };
+		02BD21E621E0EF4E00E023B9 /* arc4.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213B21E0EF4D00E023B9 /* arc4.c */; };
+		02BD21E721E0EF4E00E023B9 /* timing.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213C21E0EF4D00E023B9 /* timing.c */; };
+		02BD21E821E0EF4E00E023B9 /* xtea.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213D21E0EF4D00E023B9 /* xtea.c */; };
+		02BD21E921E0EF4E00E023B9 /* x509write_crt.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213E21E0EF4D00E023B9 /* x509write_crt.c */; };
+		02BD21EA21E0EF4E00E023B9 /* threading.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213F21E0EF4D00E023B9 /* threading.c */; };
+		02BD21EB21E0EF4E00E023B9 /* padlock.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD214021E0EF4D00E023B9 /* padlock.c */; };
+		02BD21EC21E0EF4E00E023B9 /* pkcs12.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD214121E0EF4D00E023B9 /* pkcs12.c */; };
+		02BD21ED21E0EF4E00E023B9 /* entropy.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD214221E0EF4D00E023B9 /* entropy.c */; };
+		02BD21EE21E0EF4E00E023B9 /* net_sockets.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD214321E0EF4D00E023B9 /* net_sockets.c */; };
+		02BD21EF21E0EF4E00E023B9 /* sha512.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD214421E0EF4D00E023B9 /* sha512.c */; };
+		02BD21F021E0EF4E00E023B9 /* md.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD214521E0EF4D00E023B9 /* md.c */; };
+		02BD21F121E0EF4E00E023B9 /* ecjpake.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD214621E0EF4D00E023B9 /* ecjpake.c */; };
+		02BD21F221E0EF4E00E023B9 /* cipher.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD214721E0EF4D00E023B9 /* cipher.c */; };
+		02BD21F321E0EF4E00E023B9 /* ecdsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD214821E0EF4D00E023B9 /* ecdsa.c */; };
+		02BD21F421E0EF4E00E023B9 /* zlib_util.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD214A21E0EF4D00E023B9 /* zlib_util.h */; };
+		02BD21F521E0EF4E00E023B9 /* base_util.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD214B21E0EF4D00E023B9 /* base_util.h */; };
+		02BD21F721E0EF4E00E023B9 /* console_util.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD214D21E0EF4D00E023B9 /* console_util.c */; };
+		02BD21F821E0EF4E00E023B9 /* construct_data.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD214E21E0EF4D00E023B9 /* construct_data.h */; };
+		02BD21F921E0EF4E00E023B9 /* cJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD214F21E0EF4D00E023B9 /* cJSON.h */; };
+		02BD21FA21E0EF4E00E023B9 /* directory_util.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD215021E0EF4D00E023B9 /* directory_util.c */; };
+		02BD21FB21E0EF4E00E023B9 /* aes_util.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD215121E0EF4D00E023B9 /* aes_util.h */; };
+		02BD21FC21E0EF4E00E023B9 /* clogan_core.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD215221E0EF4D00E023B9 /* clogan_core.h */; };
+		02BD21FD21E0EF4E00E023B9 /* mmap_util.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD215321E0EF4D00E023B9 /* mmap_util.c */; };
+		02BD21FE21E0EF4E00E023B9 /* json_util.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD215421E0EF4D00E023B9 /* json_util.h */; };
+		02BD21FF21E0EF4E00E023B9 /* logan_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD215521E0EF4D00E023B9 /* logan_config.h */; };
+		02BD220021E0EF4E00E023B9 /* base_util.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD215621E0EF4D00E023B9 /* base_util.c */; };
+		02BD220121E0EF4E00E023B9 /* zlib_util.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD215721E0EF4D00E023B9 /* zlib_util.c */; };
+		02BD220221E0EF4E00E023B9 /* cJSON.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD215821E0EF4D00E023B9 /* cJSON.c */; };
+		02BD220321E0EF4E00E023B9 /* construct_data.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD215921E0EF4D00E023B9 /* construct_data.c */; };
+		02BD220421E0EF4E00E023B9 /* console_util.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD215A21E0EF4D00E023B9 /* console_util.h */; };
+		02BD220621E0EF4E00E023B9 /* clogan_status.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD215C21E0EF4D00E023B9 /* clogan_status.h */; };
+		02BD220721E0EF4E00E023B9 /* directory_util.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD215D21E0EF4D00E023B9 /* directory_util.h */; };
+		02BD220821E0EF4E00E023B9 /* aes_util.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD215E21E0EF4D00E023B9 /* aes_util.c */; };
+		02BD220921E0EF4E00E023B9 /* json_util.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD215F21E0EF4D00E023B9 /* json_util.c */; };
+		02BD220A21E0EF4E00E023B9 /* mmap_util.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD216021E0EF4D00E023B9 /* mmap_util.h */; };
+		02BD220B21E0EF4E00E023B9 /* clogan_core.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD216121E0EF4D00E023B9 /* clogan_core.c */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		02BD1F4D21E0BCBB00E023B9 /* LoganSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LoganSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		02BD1F5021E0BCBB00E023B9 /* LoganSwift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LoganSwift.h; sourceTree = "<group>"; };
+		02BD1F5121E0BCBB00E023B9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		02BD20B121E0E6A400E023B9 /* LoganSwift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoganSwift.swift; sourceTree = "<group>"; };
+		02BD20B521E0EF4D00E023B9 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
+		02BD20B721E0EF4D00E023B9 /* pem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pem.h; sourceTree = "<group>"; };
+		02BD20B821E0EF4D00E023B9 /* check_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = check_config.h; sourceTree = "<group>"; };
+		02BD20B921E0EF4D00E023B9 /* error.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = error.h; sourceTree = "<group>"; };
+		02BD20BA21E0EF4D00E023B9 /* md2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = md2.h; sourceTree = "<group>"; };
+		02BD20BB21E0EF4D00E023B9 /* oid.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = oid.h; sourceTree = "<group>"; };
+		02BD20BC21E0EF4D00E023B9 /* pkcs5.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pkcs5.h; sourceTree = "<group>"; };
+		02BD20BD21E0EF4D00E023B9 /* ripemd160.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ripemd160.h; sourceTree = "<group>"; };
+		02BD20BE21E0EF4D00E023B9 /* blowfish.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = blowfish.h; sourceTree = "<group>"; };
+		02BD20BF21E0EF4D00E023B9 /* debug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = debug.h; sourceTree = "<group>"; };
+		02BD20C021E0EF4D00E023B9 /* x509.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = x509.h; sourceTree = "<group>"; };
+		02BD20C121E0EF4D00E023B9 /* version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = version.h; sourceTree = "<group>"; };
+		02BD20C221E0EF4D00E023B9 /* ecp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ecp.h; sourceTree = "<group>"; };
+		02BD20C321E0EF4D00E023B9 /* net.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = net.h; sourceTree = "<group>"; };
+		02BD20C421E0EF4D00E023B9 /* cipher_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cipher_internal.h; sourceTree = "<group>"; };
+		02BD20C521E0EF4D00E023B9 /* md_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = md_internal.h; sourceTree = "<group>"; };
+		02BD20C621E0EF4D00E023B9 /* base64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = base64.h; sourceTree = "<group>"; };
+		02BD20C721E0EF4D00E023B9 /* pkcs11.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pkcs11.h; sourceTree = "<group>"; };
+		02BD20C821E0EF4D00E023B9 /* ssl_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ssl_internal.h; sourceTree = "<group>"; };
+		02BD20C921E0EF4D00E023B9 /* asn1.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = asn1.h; sourceTree = "<group>"; };
+		02BD20CA21E0EF4D00E023B9 /* config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = config.h; sourceTree = "<group>"; };
+		02BD20CB21E0EF4D00E023B9 /* memory_buffer_alloc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = memory_buffer_alloc.h; sourceTree = "<group>"; };
+		02BD20CC21E0EF4D00E023B9 /* x509_csr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = x509_csr.h; sourceTree = "<group>"; };
+		02BD20CD21E0EF4D00E023B9 /* xtea.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = xtea.h; sourceTree = "<group>"; };
+		02BD20CE21E0EF4D00E023B9 /* threading.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = threading.h; sourceTree = "<group>"; };
+		02BD20CF21E0EF4D00E023B9 /* compat-1.3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "compat-1.3.h"; sourceTree = "<group>"; };
+		02BD20D021E0EF4D00E023B9 /* md5.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = md5.h; sourceTree = "<group>"; };
+		02BD20D121E0EF4D00E023B9 /* timing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = timing.h; sourceTree = "<group>"; };
+		02BD20D221E0EF4D00E023B9 /* arc4.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = arc4.h; sourceTree = "<group>"; };
+		02BD20D321E0EF4D00E023B9 /* sha256.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sha256.h; sourceTree = "<group>"; };
+		02BD20D421E0EF4D00E023B9 /* ecdsa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ecdsa.h; sourceTree = "<group>"; };
+		02BD20D521E0EF4D00E023B9 /* md.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = md.h; sourceTree = "<group>"; };
+		02BD20D621E0EF4D00E023B9 /* cipher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cipher.h; sourceTree = "<group>"; };
+		02BD20D721E0EF4D00E023B9 /* ecjpake.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ecjpake.h; sourceTree = "<group>"; };
+		02BD20D821E0EF4D00E023B9 /* net_sockets.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = net_sockets.h; sourceTree = "<group>"; };
+		02BD20D921E0EF4D00E023B9 /* entropy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = entropy.h; sourceTree = "<group>"; };
+		02BD20DA21E0EF4D00E023B9 /* pkcs12.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pkcs12.h; sourceTree = "<group>"; };
+		02BD20DB21E0EF4D00E023B9 /* padlock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = padlock.h; sourceTree = "<group>"; };
+		02BD20DC21E0EF4D00E023B9 /* sha512.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sha512.h; sourceTree = "<group>"; };
+		02BD20DD21E0EF4D00E023B9 /* bn_mul.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bn_mul.h; sourceTree = "<group>"; };
+		02BD20DE21E0EF4D00E023B9 /* pk.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pk.h; sourceTree = "<group>"; };
+		02BD20DF21E0EF4D00E023B9 /* ecp_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ecp_internal.h; sourceTree = "<group>"; };
+		02BD20E021E0EF4D00E023B9 /* ssl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ssl.h; sourceTree = "<group>"; };
+		02BD20E121E0EF4D00E023B9 /* platform_time.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = platform_time.h; sourceTree = "<group>"; };
+		02BD20E221E0EF4D00E023B9 /* camellia.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = camellia.h; sourceTree = "<group>"; };
+		02BD20E321E0EF4D00E023B9 /* md4.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = md4.h; sourceTree = "<group>"; };
+		02BD20E421E0EF4D00E023B9 /* x509_crt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = x509_crt.h; sourceTree = "<group>"; };
+		02BD20E521E0EF4D00E023B9 /* aes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aes.h; sourceTree = "<group>"; };
+		02BD20E621E0EF4D00E023B9 /* pk_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pk_internal.h; sourceTree = "<group>"; };
+		02BD20E721E0EF4D00E023B9 /* ssl_cookie.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ssl_cookie.h; sourceTree = "<group>"; };
+		02BD20E821E0EF4D00E023B9 /* dhm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dhm.h; sourceTree = "<group>"; };
+		02BD20E921E0EF4D00E023B9 /* aesni.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aesni.h; sourceTree = "<group>"; };
+		02BD20EA21E0EF4D00E023B9 /* ctr_drbg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ctr_drbg.h; sourceTree = "<group>"; };
+		02BD20EB21E0EF4D00E023B9 /* des.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = des.h; sourceTree = "<group>"; };
+		02BD20EC21E0EF4D00E023B9 /* x509_crl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = x509_crl.h; sourceTree = "<group>"; };
+		02BD20ED21E0EF4D00E023B9 /* ecdh.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ecdh.h; sourceTree = "<group>"; };
+		02BD20EE21E0EF4D00E023B9 /* sha1.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sha1.h; sourceTree = "<group>"; };
+		02BD20EF21E0EF4D00E023B9 /* gcm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gcm.h; sourceTree = "<group>"; };
+		02BD20F021E0EF4D00E023B9 /* certs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = certs.h; sourceTree = "<group>"; };
+		02BD20F121E0EF4D00E023B9 /* rsa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rsa.h; sourceTree = "<group>"; };
+		02BD20F221E0EF4D00E023B9 /* hmac_drbg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hmac_drbg.h; sourceTree = "<group>"; };
+		02BD20F321E0EF4D00E023B9 /* ssl_ticket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ssl_ticket.h; sourceTree = "<group>"; };
+		02BD20F421E0EF4D00E023B9 /* ssl_ciphersuites.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ssl_ciphersuites.h; sourceTree = "<group>"; };
+		02BD20F521E0EF4D00E023B9 /* ssl_cache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ssl_cache.h; sourceTree = "<group>"; };
+		02BD20F621E0EF4D00E023B9 /* cmac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cmac.h; sourceTree = "<group>"; };
+		02BD20F721E0EF4D00E023B9 /* platform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = platform.h; sourceTree = "<group>"; };
+		02BD20F821E0EF4D00E023B9 /* bignum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bignum.h; sourceTree = "<group>"; };
+		02BD20F921E0EF4D00E023B9 /* entropy_poll.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = entropy_poll.h; sourceTree = "<group>"; };
+		02BD20FA21E0EF4D00E023B9 /* havege.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = havege.h; sourceTree = "<group>"; };
+		02BD20FB21E0EF4D00E023B9 /* asn1write.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = asn1write.h; sourceTree = "<group>"; };
+		02BD20FC21E0EF4D00E023B9 /* ccm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ccm.h; sourceTree = "<group>"; };
+		02BD20FF21E0EF4D00E023B9 /* x509_create.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509_create.c; sourceTree = "<group>"; };
+		02BD210021E0EF4D00E023B9 /* x509_crt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509_crt.c; sourceTree = "<group>"; };
+		02BD210121E0EF4D00E023B9 /* aes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aes.c; sourceTree = "<group>"; };
+		02BD210221E0EF4D00E023B9 /* md4.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = md4.c; sourceTree = "<group>"; };
+		02BD210321E0EF4D00E023B9 /* ssl_srv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ssl_srv.c; sourceTree = "<group>"; };
+		02BD210421E0EF4D00E023B9 /* camellia.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = camellia.c; sourceTree = "<group>"; };
+		02BD210521E0EF4D00E023B9 /* pk_wrap.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pk_wrap.c; sourceTree = "<group>"; };
+		02BD210621E0EF4D00E023B9 /* pk.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pk.c; sourceTree = "<group>"; };
+		02BD210721E0EF4D00E023B9 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
+		02BD210821E0EF4D00E023B9 /* ecdh.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecdh.c; sourceTree = "<group>"; };
+		02BD210921E0EF4D00E023B9 /* ssl_tls.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ssl_tls.c; sourceTree = "<group>"; };
+		02BD210A21E0EF4D00E023B9 /* x509_crl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509_crl.c; sourceTree = "<group>"; };
+		02BD210B21E0EF4D00E023B9 /* cipher_wrap.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cipher_wrap.c; sourceTree = "<group>"; };
+		02BD210C21E0EF4D00E023B9 /* des.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = des.c; sourceTree = "<group>"; };
+		02BD210D21E0EF4D00E023B9 /* ssl_cookie.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ssl_cookie.c; sourceTree = "<group>"; };
+		02BD210E21E0EF4D00E023B9 /* ctr_drbg.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ctr_drbg.c; sourceTree = "<group>"; };
+		02BD210F21E0EF4D00E023B9 /* aesni.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aesni.c; sourceTree = "<group>"; };
+		02BD211021E0EF4D00E023B9 /* dhm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dhm.c; sourceTree = "<group>"; };
+		02BD211121E0EF4D00E023B9 /* ssl_cache.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ssl_cache.c; sourceTree = "<group>"; };
+		02BD211221E0EF4D00E023B9 /* ssl_ciphersuites.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ssl_ciphersuites.c; sourceTree = "<group>"; };
+		02BD211321E0EF4D00E023B9 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		02BD211421E0EF4D00E023B9 /* hmac_drbg.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hmac_drbg.c; sourceTree = "<group>"; };
+		02BD211521E0EF4D00E023B9 /* rsa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rsa.c; sourceTree = "<group>"; };
+		02BD211621E0EF4D00E023B9 /* ssl_ticket.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ssl_ticket.c; sourceTree = "<group>"; };
+		02BD211721E0EF4D00E023B9 /* asn1parse.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = asn1parse.c; sourceTree = "<group>"; };
+		02BD211821E0EF4D00E023B9 /* certs.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = certs.c; sourceTree = "<group>"; };
+		02BD211921E0EF4D00E023B9 /* pkwrite.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkwrite.c; sourceTree = "<group>"; };
+		02BD211A21E0EF4D00E023B9 /* gcm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gcm.c; sourceTree = "<group>"; };
+		02BD211B21E0EF4D00E023B9 /* sha1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sha1.c; sourceTree = "<group>"; };
+		02BD211C21E0EF4D00E023B9 /* asn1write.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = asn1write.c; sourceTree = "<group>"; };
+		02BD211D21E0EF4D00E023B9 /* havege.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = havege.c; sourceTree = "<group>"; };
+		02BD211E21E0EF4D00E023B9 /* ccm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ccm.c; sourceTree = "<group>"; };
+		02BD211F21E0EF4D00E023B9 /* version_features.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = version_features.c; sourceTree = "<group>"; };
+		02BD212021E0EF4D00E023B9 /* entropy_poll.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = entropy_poll.c; sourceTree = "<group>"; };
+		02BD212121E0EF4D00E023B9 /* x509write_csr.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509write_csr.c; sourceTree = "<group>"; };
+		02BD212221E0EF4D00E023B9 /* platform.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = platform.c; sourceTree = "<group>"; };
+		02BD212321E0EF4D00E023B9 /* cmac.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cmac.c; sourceTree = "<group>"; };
+		02BD212421E0EF4D00E023B9 /* bignum.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bignum.c; sourceTree = "<group>"; };
+		02BD212521E0EF4D00E023B9 /* pkparse.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkparse.c; sourceTree = "<group>"; };
+		02BD212621E0EF4D00E023B9 /* debug.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = debug.c; sourceTree = "<group>"; };
+		02BD212721E0EF4D00E023B9 /* ripemd160.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ripemd160.c; sourceTree = "<group>"; };
+		02BD212821E0EF4D00E023B9 /* ssl_cli.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ssl_cli.c; sourceTree = "<group>"; };
+		02BD212921E0EF4D00E023B9 /* blowfish.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = blowfish.c; sourceTree = "<group>"; };
+		02BD212A21E0EF4D00E023B9 /* pkcs5.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkcs5.c; sourceTree = "<group>"; };
+		02BD212B21E0EF4D00E023B9 /* pem.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pem.c; sourceTree = "<group>"; };
+		02BD212C21E0EF4D00E023B9 /* .gitignore */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
+		02BD212D21E0EF4D00E023B9 /* oid.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = oid.c; sourceTree = "<group>"; };
+		02BD212E21E0EF4D00E023B9 /* error.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = error.c; sourceTree = "<group>"; };
+		02BD212F21E0EF4D00E023B9 /* md2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = md2.c; sourceTree = "<group>"; };
+		02BD213021E0EF4D00E023B9 /* md_wrap.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = md_wrap.c; sourceTree = "<group>"; };
+		02BD213121E0EF4D00E023B9 /* x509_csr.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509_csr.c; sourceTree = "<group>"; };
+		02BD213221E0EF4D00E023B9 /* pkcs11.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkcs11.c; sourceTree = "<group>"; };
+		02BD213321E0EF4D00E023B9 /* base64.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = base64.c; sourceTree = "<group>"; };
+		02BD213421E0EF4D00E023B9 /* memory_buffer_alloc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = memory_buffer_alloc.c; sourceTree = "<group>"; };
+		02BD213521E0EF4D00E023B9 /* ecp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecp.c; sourceTree = "<group>"; };
+		02BD213621E0EF4D00E023B9 /* version.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = version.c; sourceTree = "<group>"; };
+		02BD213721E0EF4D00E023B9 /* x509.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509.c; sourceTree = "<group>"; };
+		02BD213821E0EF4D00E023B9 /* sha256.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sha256.c; sourceTree = "<group>"; };
+		02BD213921E0EF4D00E023B9 /* ecp_curves.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecp_curves.c; sourceTree = "<group>"; };
+		02BD213A21E0EF4D00E023B9 /* md5.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = md5.c; sourceTree = "<group>"; };
+		02BD213B21E0EF4D00E023B9 /* arc4.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = arc4.c; sourceTree = "<group>"; };
+		02BD213C21E0EF4D00E023B9 /* timing.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = timing.c; sourceTree = "<group>"; };
+		02BD213D21E0EF4D00E023B9 /* xtea.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = xtea.c; sourceTree = "<group>"; };
+		02BD213E21E0EF4D00E023B9 /* x509write_crt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509write_crt.c; sourceTree = "<group>"; };
+		02BD213F21E0EF4D00E023B9 /* threading.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = threading.c; sourceTree = "<group>"; };
+		02BD214021E0EF4D00E023B9 /* padlock.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = padlock.c; sourceTree = "<group>"; };
+		02BD214121E0EF4D00E023B9 /* pkcs12.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkcs12.c; sourceTree = "<group>"; };
+		02BD214221E0EF4D00E023B9 /* entropy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = entropy.c; sourceTree = "<group>"; };
+		02BD214321E0EF4D00E023B9 /* net_sockets.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = net_sockets.c; sourceTree = "<group>"; };
+		02BD214421E0EF4D00E023B9 /* sha512.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sha512.c; sourceTree = "<group>"; };
+		02BD214521E0EF4D00E023B9 /* md.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = md.c; sourceTree = "<group>"; };
+		02BD214621E0EF4D00E023B9 /* ecjpake.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecjpake.c; sourceTree = "<group>"; };
+		02BD214721E0EF4D00E023B9 /* cipher.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cipher.c; sourceTree = "<group>"; };
+		02BD214821E0EF4D00E023B9 /* ecdsa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecdsa.c; sourceTree = "<group>"; };
+		02BD214A21E0EF4D00E023B9 /* zlib_util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = zlib_util.h; sourceTree = "<group>"; };
+		02BD214B21E0EF4D00E023B9 /* base_util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = base_util.h; sourceTree = "<group>"; };
+		02BD214C21E0EF4D00E023B9 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
+		02BD214D21E0EF4D00E023B9 /* console_util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = console_util.c; sourceTree = "<group>"; };
+		02BD214E21E0EF4D00E023B9 /* construct_data.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = construct_data.h; sourceTree = "<group>"; };
+		02BD214F21E0EF4D00E023B9 /* cJSON.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cJSON.h; sourceTree = "<group>"; };
+		02BD215021E0EF4D00E023B9 /* directory_util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = directory_util.c; sourceTree = "<group>"; };
+		02BD215121E0EF4D00E023B9 /* aes_util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aes_util.h; sourceTree = "<group>"; };
+		02BD215221E0EF4D00E023B9 /* clogan_core.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = clogan_core.h; sourceTree = "<group>"; };
+		02BD215321E0EF4D00E023B9 /* mmap_util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = mmap_util.c; sourceTree = "<group>"; };
+		02BD215421E0EF4D00E023B9 /* json_util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = json_util.h; sourceTree = "<group>"; };
+		02BD215521E0EF4D00E023B9 /* logan_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = logan_config.h; sourceTree = "<group>"; };
+		02BD215621E0EF4D00E023B9 /* base_util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = base_util.c; sourceTree = "<group>"; };
+		02BD215721E0EF4D00E023B9 /* zlib_util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = zlib_util.c; sourceTree = "<group>"; };
+		02BD215821E0EF4D00E023B9 /* cJSON.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cJSON.c; sourceTree = "<group>"; };
+		02BD215921E0EF4D00E023B9 /* construct_data.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = construct_data.c; sourceTree = "<group>"; };
+		02BD215A21E0EF4D00E023B9 /* console_util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = console_util.h; sourceTree = "<group>"; };
+		02BD215B21E0EF4D00E023B9 /* main.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; path = main.dSYM; sourceTree = "<group>"; };
+		02BD215C21E0EF4D00E023B9 /* clogan_status.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = clogan_status.h; sourceTree = "<group>"; };
+		02BD215D21E0EF4D00E023B9 /* directory_util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = directory_util.h; sourceTree = "<group>"; };
+		02BD215E21E0EF4D00E023B9 /* aes_util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aes_util.c; sourceTree = "<group>"; };
+		02BD215F21E0EF4D00E023B9 /* json_util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = json_util.c; sourceTree = "<group>"; };
+		02BD216021E0EF4D00E023B9 /* mmap_util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mmap_util.h; sourceTree = "<group>"; };
+		02BD216121E0EF4D00E023B9 /* clogan_core.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = clogan_core.c; sourceTree = "<group>"; };
+		02BD220C21E0F90600E023B9 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		02BD1F4A21E0BCBB00E023B9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		02BD1F4321E0BCBB00E023B9 = {
+			isa = PBXGroup;
+			children = (
+				02BD214921E0EF4D00E023B9 /* Clogan */,
+				02BD20B321E0EF4D00E023B9 /* mbedtls */,
+				02BD1F4F21E0BCBB00E023B9 /* LoganSwift */,
+				02BD1F4E21E0BCBB00E023B9 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		02BD1F4E21E0BCBB00E023B9 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				02BD1F4D21E0BCBB00E023B9 /* LoganSwift.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		02BD1F4F21E0BCBB00E023B9 /* LoganSwift */ = {
+			isa = PBXGroup;
+			children = (
+				02BD1F5021E0BCBB00E023B9 /* LoganSwift.h */,
+				02BD1F5121E0BCBB00E023B9 /* Info.plist */,
+				02BD20B121E0E6A400E023B9 /* LoganSwift.swift */,
+			);
+			path = LoganSwift;
+			sourceTree = "<group>";
+		};
+		02BD20B321E0EF4D00E023B9 /* mbedtls */ = {
+			isa = PBXGroup;
+			children = (
+				02BD20B421E0EF4D00E023B9 /* include */,
+				02BD20FE21E0EF4D00E023B9 /* library */,
+			);
+			name = mbedtls;
+			path = ../../Logan/mbedtls;
+			sourceTree = "<group>";
+		};
+		02BD20B421E0EF4D00E023B9 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				02BD20B521E0EF4D00E023B9 /* CMakeLists.txt */,
+				02BD20B621E0EF4D00E023B9 /* mbedtls */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		02BD20B621E0EF4D00E023B9 /* mbedtls */ = {
+			isa = PBXGroup;
+			children = (
+				02BD20B721E0EF4D00E023B9 /* pem.h */,
+				02BD20B821E0EF4D00E023B9 /* check_config.h */,
+				02BD20B921E0EF4D00E023B9 /* error.h */,
+				02BD20BA21E0EF4D00E023B9 /* md2.h */,
+				02BD20BB21E0EF4D00E023B9 /* oid.h */,
+				02BD20BC21E0EF4D00E023B9 /* pkcs5.h */,
+				02BD20BD21E0EF4D00E023B9 /* ripemd160.h */,
+				02BD20BE21E0EF4D00E023B9 /* blowfish.h */,
+				02BD20BF21E0EF4D00E023B9 /* debug.h */,
+				02BD20C021E0EF4D00E023B9 /* x509.h */,
+				02BD20C121E0EF4D00E023B9 /* version.h */,
+				02BD20C221E0EF4D00E023B9 /* ecp.h */,
+				02BD20C321E0EF4D00E023B9 /* net.h */,
+				02BD20C421E0EF4D00E023B9 /* cipher_internal.h */,
+				02BD20C521E0EF4D00E023B9 /* md_internal.h */,
+				02BD20C621E0EF4D00E023B9 /* base64.h */,
+				02BD20C721E0EF4D00E023B9 /* pkcs11.h */,
+				02BD20C821E0EF4D00E023B9 /* ssl_internal.h */,
+				02BD20C921E0EF4D00E023B9 /* asn1.h */,
+				02BD20CA21E0EF4D00E023B9 /* config.h */,
+				02BD20CB21E0EF4D00E023B9 /* memory_buffer_alloc.h */,
+				02BD20CC21E0EF4D00E023B9 /* x509_csr.h */,
+				02BD20CD21E0EF4D00E023B9 /* xtea.h */,
+				02BD20CE21E0EF4D00E023B9 /* threading.h */,
+				02BD20CF21E0EF4D00E023B9 /* compat-1.3.h */,
+				02BD20D021E0EF4D00E023B9 /* md5.h */,
+				02BD20D121E0EF4D00E023B9 /* timing.h */,
+				02BD20D221E0EF4D00E023B9 /* arc4.h */,
+				02BD20D321E0EF4D00E023B9 /* sha256.h */,
+				02BD20D421E0EF4D00E023B9 /* ecdsa.h */,
+				02BD20D521E0EF4D00E023B9 /* md.h */,
+				02BD20D621E0EF4D00E023B9 /* cipher.h */,
+				02BD20D721E0EF4D00E023B9 /* ecjpake.h */,
+				02BD20D821E0EF4D00E023B9 /* net_sockets.h */,
+				02BD20D921E0EF4D00E023B9 /* entropy.h */,
+				02BD20DA21E0EF4D00E023B9 /* pkcs12.h */,
+				02BD20DB21E0EF4D00E023B9 /* padlock.h */,
+				02BD20DC21E0EF4D00E023B9 /* sha512.h */,
+				02BD20DD21E0EF4D00E023B9 /* bn_mul.h */,
+				02BD20DE21E0EF4D00E023B9 /* pk.h */,
+				02BD20DF21E0EF4D00E023B9 /* ecp_internal.h */,
+				02BD20E021E0EF4D00E023B9 /* ssl.h */,
+				02BD20E121E0EF4D00E023B9 /* platform_time.h */,
+				02BD20E221E0EF4D00E023B9 /* camellia.h */,
+				02BD20E321E0EF4D00E023B9 /* md4.h */,
+				02BD20E421E0EF4D00E023B9 /* x509_crt.h */,
+				02BD20E521E0EF4D00E023B9 /* aes.h */,
+				02BD20E621E0EF4D00E023B9 /* pk_internal.h */,
+				02BD20E721E0EF4D00E023B9 /* ssl_cookie.h */,
+				02BD20E821E0EF4D00E023B9 /* dhm.h */,
+				02BD20E921E0EF4D00E023B9 /* aesni.h */,
+				02BD20EA21E0EF4D00E023B9 /* ctr_drbg.h */,
+				02BD20EB21E0EF4D00E023B9 /* des.h */,
+				02BD20EC21E0EF4D00E023B9 /* x509_crl.h */,
+				02BD20ED21E0EF4D00E023B9 /* ecdh.h */,
+				02BD20EE21E0EF4D00E023B9 /* sha1.h */,
+				02BD20EF21E0EF4D00E023B9 /* gcm.h */,
+				02BD20F021E0EF4D00E023B9 /* certs.h */,
+				02BD20F121E0EF4D00E023B9 /* rsa.h */,
+				02BD20F221E0EF4D00E023B9 /* hmac_drbg.h */,
+				02BD20F321E0EF4D00E023B9 /* ssl_ticket.h */,
+				02BD20F421E0EF4D00E023B9 /* ssl_ciphersuites.h */,
+				02BD20F521E0EF4D00E023B9 /* ssl_cache.h */,
+				02BD20F621E0EF4D00E023B9 /* cmac.h */,
+				02BD20F721E0EF4D00E023B9 /* platform.h */,
+				02BD20F821E0EF4D00E023B9 /* bignum.h */,
+				02BD20F921E0EF4D00E023B9 /* entropy_poll.h */,
+				02BD20FA21E0EF4D00E023B9 /* havege.h */,
+				02BD20FB21E0EF4D00E023B9 /* asn1write.h */,
+				02BD20FC21E0EF4D00E023B9 /* ccm.h */,
+			);
+			path = mbedtls;
+			sourceTree = "<group>";
+		};
+		02BD20FE21E0EF4D00E023B9 /* library */ = {
+			isa = PBXGroup;
+			children = (
+				02BD20FF21E0EF4D00E023B9 /* x509_create.c */,
+				02BD210021E0EF4D00E023B9 /* x509_crt.c */,
+				02BD210121E0EF4D00E023B9 /* aes.c */,
+				02BD210221E0EF4D00E023B9 /* md4.c */,
+				02BD210321E0EF4D00E023B9 /* ssl_srv.c */,
+				02BD210421E0EF4D00E023B9 /* camellia.c */,
+				02BD210521E0EF4D00E023B9 /* pk_wrap.c */,
+				02BD210621E0EF4D00E023B9 /* pk.c */,
+				02BD210721E0EF4D00E023B9 /* CMakeLists.txt */,
+				02BD210821E0EF4D00E023B9 /* ecdh.c */,
+				02BD210921E0EF4D00E023B9 /* ssl_tls.c */,
+				02BD210A21E0EF4D00E023B9 /* x509_crl.c */,
+				02BD210B21E0EF4D00E023B9 /* cipher_wrap.c */,
+				02BD210C21E0EF4D00E023B9 /* des.c */,
+				02BD210D21E0EF4D00E023B9 /* ssl_cookie.c */,
+				02BD210E21E0EF4D00E023B9 /* ctr_drbg.c */,
+				02BD210F21E0EF4D00E023B9 /* aesni.c */,
+				02BD211021E0EF4D00E023B9 /* dhm.c */,
+				02BD211121E0EF4D00E023B9 /* ssl_cache.c */,
+				02BD211221E0EF4D00E023B9 /* ssl_ciphersuites.c */,
+				02BD211321E0EF4D00E023B9 /* Makefile */,
+				02BD211421E0EF4D00E023B9 /* hmac_drbg.c */,
+				02BD211521E0EF4D00E023B9 /* rsa.c */,
+				02BD211621E0EF4D00E023B9 /* ssl_ticket.c */,
+				02BD211721E0EF4D00E023B9 /* asn1parse.c */,
+				02BD211821E0EF4D00E023B9 /* certs.c */,
+				02BD211921E0EF4D00E023B9 /* pkwrite.c */,
+				02BD211A21E0EF4D00E023B9 /* gcm.c */,
+				02BD211B21E0EF4D00E023B9 /* sha1.c */,
+				02BD211C21E0EF4D00E023B9 /* asn1write.c */,
+				02BD211D21E0EF4D00E023B9 /* havege.c */,
+				02BD211E21E0EF4D00E023B9 /* ccm.c */,
+				02BD211F21E0EF4D00E023B9 /* version_features.c */,
+				02BD212021E0EF4D00E023B9 /* entropy_poll.c */,
+				02BD212121E0EF4D00E023B9 /* x509write_csr.c */,
+				02BD212221E0EF4D00E023B9 /* platform.c */,
+				02BD212321E0EF4D00E023B9 /* cmac.c */,
+				02BD212421E0EF4D00E023B9 /* bignum.c */,
+				02BD212521E0EF4D00E023B9 /* pkparse.c */,
+				02BD212621E0EF4D00E023B9 /* debug.c */,
+				02BD212721E0EF4D00E023B9 /* ripemd160.c */,
+				02BD212821E0EF4D00E023B9 /* ssl_cli.c */,
+				02BD212921E0EF4D00E023B9 /* blowfish.c */,
+				02BD212A21E0EF4D00E023B9 /* pkcs5.c */,
+				02BD212B21E0EF4D00E023B9 /* pem.c */,
+				02BD212C21E0EF4D00E023B9 /* .gitignore */,
+				02BD212D21E0EF4D00E023B9 /* oid.c */,
+				02BD212E21E0EF4D00E023B9 /* error.c */,
+				02BD212F21E0EF4D00E023B9 /* md2.c */,
+				02BD213021E0EF4D00E023B9 /* md_wrap.c */,
+				02BD213121E0EF4D00E023B9 /* x509_csr.c */,
+				02BD213221E0EF4D00E023B9 /* pkcs11.c */,
+				02BD213321E0EF4D00E023B9 /* base64.c */,
+				02BD213421E0EF4D00E023B9 /* memory_buffer_alloc.c */,
+				02BD213521E0EF4D00E023B9 /* ecp.c */,
+				02BD213621E0EF4D00E023B9 /* version.c */,
+				02BD213721E0EF4D00E023B9 /* x509.c */,
+				02BD213821E0EF4D00E023B9 /* sha256.c */,
+				02BD213921E0EF4D00E023B9 /* ecp_curves.c */,
+				02BD213A21E0EF4D00E023B9 /* md5.c */,
+				02BD213B21E0EF4D00E023B9 /* arc4.c */,
+				02BD213C21E0EF4D00E023B9 /* timing.c */,
+				02BD213D21E0EF4D00E023B9 /* xtea.c */,
+				02BD213E21E0EF4D00E023B9 /* x509write_crt.c */,
+				02BD213F21E0EF4D00E023B9 /* threading.c */,
+				02BD214021E0EF4D00E023B9 /* padlock.c */,
+				02BD214121E0EF4D00E023B9 /* pkcs12.c */,
+				02BD214221E0EF4D00E023B9 /* entropy.c */,
+				02BD214321E0EF4D00E023B9 /* net_sockets.c */,
+				02BD214421E0EF4D00E023B9 /* sha512.c */,
+				02BD214521E0EF4D00E023B9 /* md.c */,
+				02BD214621E0EF4D00E023B9 /* ecjpake.c */,
+				02BD214721E0EF4D00E023B9 /* cipher.c */,
+				02BD214821E0EF4D00E023B9 /* ecdsa.c */,
+			);
+			path = library;
+			sourceTree = "<group>";
+		};
+		02BD214921E0EF4D00E023B9 /* Clogan */ = {
+			isa = PBXGroup;
+			children = (
+				02BD214A21E0EF4D00E023B9 /* zlib_util.h */,
+				02BD214B21E0EF4D00E023B9 /* base_util.h */,
+				02BD214C21E0EF4D00E023B9 /* CMakeLists.txt */,
+				02BD214D21E0EF4D00E023B9 /* console_util.c */,
+				02BD214E21E0EF4D00E023B9 /* construct_data.h */,
+				02BD214F21E0EF4D00E023B9 /* cJSON.h */,
+				02BD215021E0EF4D00E023B9 /* directory_util.c */,
+				02BD215121E0EF4D00E023B9 /* aes_util.h */,
+				02BD215221E0EF4D00E023B9 /* clogan_core.h */,
+				02BD215321E0EF4D00E023B9 /* mmap_util.c */,
+				02BD215421E0EF4D00E023B9 /* json_util.h */,
+				02BD215521E0EF4D00E023B9 /* logan_config.h */,
+				02BD215621E0EF4D00E023B9 /* base_util.c */,
+				02BD215721E0EF4D00E023B9 /* zlib_util.c */,
+				02BD215821E0EF4D00E023B9 /* cJSON.c */,
+				02BD215921E0EF4D00E023B9 /* construct_data.c */,
+				02BD215A21E0EF4D00E023B9 /* console_util.h */,
+				02BD215B21E0EF4D00E023B9 /* main.dSYM */,
+				02BD215C21E0EF4D00E023B9 /* clogan_status.h */,
+				02BD215D21E0EF4D00E023B9 /* directory_util.h */,
+				02BD215E21E0EF4D00E023B9 /* aes_util.c */,
+				02BD215F21E0EF4D00E023B9 /* json_util.c */,
+				02BD216021E0EF4D00E023B9 /* mmap_util.h */,
+				02BD216121E0EF4D00E023B9 /* clogan_core.c */,
+				02BD220C21E0F90600E023B9 /* module.modulemap */,
+			);
+			name = Clogan;
+			path = ../../Logan/Clogan;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		02BD1F4821E0BCBB00E023B9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				02BD21F521E0EF4E00E023B9 /* base_util.h in Headers */,
+				02BD21A221E0EF4E00E023B9 /* cmac.h in Headers */,
+				02BD219021E0EF4E00E023B9 /* x509_crt.h in Headers */,
+				02BD219521E0EF4E00E023B9 /* aesni.h in Headers */,
+				02BD217121E0EF4E00E023B9 /* md_internal.h in Headers */,
+				02BD216C21E0EF4E00E023B9 /* x509.h in Headers */,
+				02BD216D21E0EF4E00E023B9 /* version.h in Headers */,
+				02BD217821E0EF4E00E023B9 /* x509_csr.h in Headers */,
+				02BD21A121E0EF4E00E023B9 /* ssl_cache.h in Headers */,
+				02BD218621E0EF4E00E023B9 /* pkcs12.h in Headers */,
+				02BD219821E0EF4E00E023B9 /* x509_crl.h in Headers */,
+				02BD219921E0EF4E00E023B9 /* ecdh.h in Headers */,
+				02BD219D21E0EF4E00E023B9 /* rsa.h in Headers */,
+				02BD217321E0EF4E00E023B9 /* pkcs11.h in Headers */,
+				02BD217F21E0EF4E00E023B9 /* sha256.h in Headers */,
+				02BD219621E0EF4E00E023B9 /* ctr_drbg.h in Headers */,
+				02BD21A321E0EF4E00E023B9 /* platform.h in Headers */,
+				02BD217A21E0EF4E00E023B9 /* threading.h in Headers */,
+				02BD218821E0EF4E00E023B9 /* sha512.h in Headers */,
+				02BD219B21E0EF4E00E023B9 /* gcm.h in Headers */,
+				02BD21F821E0EF4E00E023B9 /* construct_data.h in Headers */,
+				02BD217E21E0EF4E00E023B9 /* arc4.h in Headers */,
+				02BD21FF21E0EF4E00E023B9 /* logan_config.h in Headers */,
+				02BD216F21E0EF4E00E023B9 /* net.h in Headers */,
+				02BD218921E0EF4E00E023B9 /* bn_mul.h in Headers */,
+				02BD219721E0EF4E00E023B9 /* des.h in Headers */,
+				02BD21A021E0EF4E00E023B9 /* ssl_ciphersuites.h in Headers */,
+				02BD21FC21E0EF4E00E023B9 /* clogan_core.h in Headers */,
+				02BD216621E0EF4E00E023B9 /* md2.h in Headers */,
+				02BD217421E0EF4E00E023B9 /* ssl_internal.h in Headers */,
+				02BD218E21E0EF4E00E023B9 /* camellia.h in Headers */,
+				02BD21A721E0EF4E00E023B9 /* asn1write.h in Headers */,
+				02BD217C21E0EF4E00E023B9 /* md5.h in Headers */,
+				02BD218721E0EF4E00E023B9 /* padlock.h in Headers */,
+				02BD217721E0EF4E00E023B9 /* memory_buffer_alloc.h in Headers */,
+				02BD21F921E0EF4E00E023B9 /* cJSON.h in Headers */,
+				02BD219E21E0EF4E00E023B9 /* hmac_drbg.h in Headers */,
+				02BD21A521E0EF4E00E023B9 /* entropy_poll.h in Headers */,
+				02BD216921E0EF4E00E023B9 /* ripemd160.h in Headers */,
+				02BD217B21E0EF4E00E023B9 /* compat-1.3.h in Headers */,
+				02BD217221E0EF4E00E023B9 /* base64.h in Headers */,
+				02BD21A421E0EF4E00E023B9 /* bignum.h in Headers */,
+				02BD220721E0EF4E00E023B9 /* directory_util.h in Headers */,
+				02BD218D21E0EF4E00E023B9 /* platform_time.h in Headers */,
+				02BD217021E0EF4E00E023B9 /* cipher_internal.h in Headers */,
+				02BD218421E0EF4E00E023B9 /* net_sockets.h in Headers */,
+				02BD216821E0EF4E00E023B9 /* pkcs5.h in Headers */,
+				02BD216421E0EF4E00E023B9 /* check_config.h in Headers */,
+				02BD216A21E0EF4E00E023B9 /* blowfish.h in Headers */,
+				02BD1F5221E0BCBB00E023B9 /* LoganSwift.h in Headers */,
+				02BD216B21E0EF4E00E023B9 /* debug.h in Headers */,
+				02BD218021E0EF4E00E023B9 /* ecdsa.h in Headers */,
+				02BD219321E0EF4E00E023B9 /* ssl_cookie.h in Headers */,
+				02BD21F421E0EF4E00E023B9 /* zlib_util.h in Headers */,
+				02BD217521E0EF4E00E023B9 /* asn1.h in Headers */,
+				02BD219421E0EF4E00E023B9 /* dhm.h in Headers */,
+				02BD216721E0EF4E00E023B9 /* oid.h in Headers */,
+				02BD216E21E0EF4E00E023B9 /* ecp.h in Headers */,
+				02BD216321E0EF4E00E023B9 /* pem.h in Headers */,
+				02BD218F21E0EF4E00E023B9 /* md4.h in Headers */,
+				02BD220A21E0EF4E00E023B9 /* mmap_util.h in Headers */,
+				02BD21A821E0EF4E00E023B9 /* ccm.h in Headers */,
+				02BD219121E0EF4E00E023B9 /* aes.h in Headers */,
+				02BD21FE21E0EF4E00E023B9 /* json_util.h in Headers */,
+				02BD218121E0EF4E00E023B9 /* md.h in Headers */,
+				02BD218A21E0EF4E00E023B9 /* pk.h in Headers */,
+				02BD216521E0EF4E00E023B9 /* error.h in Headers */,
+				02BD217921E0EF4E00E023B9 /* xtea.h in Headers */,
+				02BD217D21E0EF4E00E023B9 /* timing.h in Headers */,
+				02BD218521E0EF4E00E023B9 /* entropy.h in Headers */,
+				02BD220421E0EF4E00E023B9 /* console_util.h in Headers */,
+				02BD21A621E0EF4E00E023B9 /* havege.h in Headers */,
+				02BD21FB21E0EF4E00E023B9 /* aes_util.h in Headers */,
+				02BD219221E0EF4E00E023B9 /* pk_internal.h in Headers */,
+				02BD218B21E0EF4E00E023B9 /* ecp_internal.h in Headers */,
+				02BD219A21E0EF4E00E023B9 /* sha1.h in Headers */,
+				02BD217621E0EF4E00E023B9 /* config.h in Headers */,
+				02BD218321E0EF4E00E023B9 /* ecjpake.h in Headers */,
+				02BD218C21E0EF4E00E023B9 /* ssl.h in Headers */,
+				02BD219C21E0EF4E00E023B9 /* certs.h in Headers */,
+				02BD220621E0EF4E00E023B9 /* clogan_status.h in Headers */,
+				02BD218221E0EF4E00E023B9 /* cipher.h in Headers */,
+				02BD219F21E0EF4E00E023B9 /* ssl_ticket.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		02BD1F4C21E0BCBB00E023B9 /* LoganSwift */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 02BD1F5521E0BCBB00E023B9 /* Build configuration list for PBXNativeTarget "LoganSwift" */;
+			buildPhases = (
+				02BD1F4821E0BCBB00E023B9 /* Headers */,
+				02BD1F4921E0BCBB00E023B9 /* Sources */,
+				02BD1F4A21E0BCBB00E023B9 /* Frameworks */,
+				02BD1F4B21E0BCBB00E023B9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = LoganSwift;
+			productName = LoganSwift;
+			productReference = 02BD1F4D21E0BCBB00E023B9 /* LoganSwift.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		02BD1F4421E0BCBB00E023B9 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1010;
+				ORGANIZATIONNAME = hanguang;
+				TargetAttributes = {
+					02BD1F4C21E0BCBB00E023B9 = {
+						CreatedOnToolsVersion = 10.1;
+						LastSwiftMigration = 1010;
+					};
+				};
+			};
+			buildConfigurationList = 02BD1F4721E0BCBB00E023B9 /* Build configuration list for PBXProject "LoganSwift" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 02BD1F4321E0BCBB00E023B9;
+			productRefGroup = 02BD1F4E21E0BCBB00E023B9 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				02BD1F4C21E0BCBB00E023B9 /* LoganSwift */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		02BD1F4B21E0BCBB00E023B9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		02BD1F4921E0BCBB00E023B9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				02BD21AF21E0EF4E00E023B9 /* camellia.c in Sources */,
+				02BD21C521E0EF4E00E023B9 /* gcm.c in Sources */,
+				02BD21DD21E0EF4E00E023B9 /* pkcs11.c in Sources */,
+				02BD21C721E0EF4E00E023B9 /* asn1write.c in Sources */,
+				02BD21F221E0EF4E00E023B9 /* cipher.c in Sources */,
+				02BD21EE21E0EF4E00E023B9 /* net_sockets.c in Sources */,
+				02BD21C321E0EF4E00E023B9 /* certs.c in Sources */,
+				02BD21CA21E0EF4E00E023B9 /* version_features.c in Sources */,
+				02BD21AB21E0EF4E00E023B9 /* x509_crt.c in Sources */,
+				02BD220221E0EF4E00E023B9 /* cJSON.c in Sources */,
+				02BD21C121E0EF4E00E023B9 /* ssl_ticket.c in Sources */,
+				02BD21F321E0EF4E00E023B9 /* ecdsa.c in Sources */,
+				02BD21B921E0EF4E00E023B9 /* ctr_drbg.c in Sources */,
+				02BD21D921E0EF4E00E023B9 /* error.c in Sources */,
+				02BD21DF21E0EF4E00E023B9 /* memory_buffer_alloc.c in Sources */,
+				02BD220B21E0EF4E00E023B9 /* clogan_core.c in Sources */,
+				02BD21DE21E0EF4E00E023B9 /* base64.c in Sources */,
+				02BD21FA21E0EF4E00E023B9 /* directory_util.c in Sources */,
+				02BD21DA21E0EF4E00E023B9 /* md2.c in Sources */,
+				02BD21EB21E0EF4E00E023B9 /* padlock.c in Sources */,
+				02BD21F121E0EF4E00E023B9 /* ecjpake.c in Sources */,
+				02BD21E221E0EF4E00E023B9 /* x509.c in Sources */,
+				02BD21F021E0EF4E00E023B9 /* md.c in Sources */,
+				02BD21BB21E0EF4E00E023B9 /* dhm.c in Sources */,
+				02BD21BC21E0EF4E00E023B9 /* ssl_cache.c in Sources */,
+				02BD21E121E0EF4E00E023B9 /* version.c in Sources */,
+				02BD21D421E0EF4E00E023B9 /* blowfish.c in Sources */,
+				02BD21EA21E0EF4E00E023B9 /* threading.c in Sources */,
+				02BD21C921E0EF4E00E023B9 /* ccm.c in Sources */,
+				02BD21C621E0EF4E00E023B9 /* sha1.c in Sources */,
+				02BD21CB21E0EF4E00E023B9 /* entropy_poll.c in Sources */,
+				02BD20B221E0E6A400E023B9 /* LoganSwift.swift in Sources */,
+				02BD220321E0EF4E00E023B9 /* construct_data.c in Sources */,
+				02BD21F721E0EF4E00E023B9 /* console_util.c in Sources */,
+				02BD21E421E0EF4E00E023B9 /* ecp_curves.c in Sources */,
+				02BD21EC21E0EF4E00E023B9 /* pkcs12.c in Sources */,
+				02BD21E821E0EF4E00E023B9 /* xtea.c in Sources */,
+				02BD21D021E0EF4E00E023B9 /* pkparse.c in Sources */,
+				02BD220921E0EF4E00E023B9 /* json_util.c in Sources */,
+				02BD21C021E0EF4E00E023B9 /* rsa.c in Sources */,
+				02BD21E621E0EF4E00E023B9 /* arc4.c in Sources */,
+				02BD21E921E0EF4E00E023B9 /* x509write_crt.c in Sources */,
+				02BD220121E0EF4E00E023B9 /* zlib_util.c in Sources */,
+				02BD21AA21E0EF4E00E023B9 /* x509_create.c in Sources */,
+				02BD21BF21E0EF4E00E023B9 /* hmac_drbg.c in Sources */,
+				02BD21B721E0EF4E00E023B9 /* des.c in Sources */,
+				02BD21DC21E0EF4E00E023B9 /* x509_csr.c in Sources */,
+				02BD21E521E0EF4E00E023B9 /* md5.c in Sources */,
+				02BD21AC21E0EF4E00E023B9 /* aes.c in Sources */,
+				02BD21E721E0EF4E00E023B9 /* timing.c in Sources */,
+				02BD21D621E0EF4E00E023B9 /* pem.c in Sources */,
+				02BD21D821E0EF4E00E023B9 /* oid.c in Sources */,
+				02BD21ED21E0EF4E00E023B9 /* entropy.c in Sources */,
+				02BD21B621E0EF4E00E023B9 /* cipher_wrap.c in Sources */,
+				02BD21E021E0EF4E00E023B9 /* ecp.c in Sources */,
+				02BD21CD21E0EF4E00E023B9 /* platform.c in Sources */,
+				02BD21CE21E0EF4E00E023B9 /* cmac.c in Sources */,
+				02BD220021E0EF4E00E023B9 /* base_util.c in Sources */,
+				02BD21BA21E0EF4E00E023B9 /* aesni.c in Sources */,
+				02BD21CF21E0EF4E00E023B9 /* bignum.c in Sources */,
+				02BD21C221E0EF4E00E023B9 /* asn1parse.c in Sources */,
+				02BD21EF21E0EF4E00E023B9 /* sha512.c in Sources */,
+				02BD21B521E0EF4E00E023B9 /* x509_crl.c in Sources */,
+				02BD220821E0EF4E00E023B9 /* aes_util.c in Sources */,
+				02BD21BE21E0EF4E00E023B9 /* Makefile in Sources */,
+				02BD21BD21E0EF4E00E023B9 /* ssl_ciphersuites.c in Sources */,
+				02BD21D221E0EF4E00E023B9 /* ripemd160.c in Sources */,
+				02BD21B321E0EF4E00E023B9 /* ecdh.c in Sources */,
+				02BD21E321E0EF4E00E023B9 /* sha256.c in Sources */,
+				02BD21D321E0EF4E00E023B9 /* ssl_cli.c in Sources */,
+				02BD21B421E0EF4E00E023B9 /* ssl_tls.c in Sources */,
+				02BD21D521E0EF4E00E023B9 /* pkcs5.c in Sources */,
+				02BD21D121E0EF4E00E023B9 /* debug.c in Sources */,
+				02BD21AE21E0EF4E00E023B9 /* ssl_srv.c in Sources */,
+				02BD21DB21E0EF4E00E023B9 /* md_wrap.c in Sources */,
+				02BD21B821E0EF4E00E023B9 /* ssl_cookie.c in Sources */,
+				02BD21C421E0EF4E00E023B9 /* pkwrite.c in Sources */,
+				02BD21CC21E0EF4E00E023B9 /* x509write_csr.c in Sources */,
+				02BD21B121E0EF4E00E023B9 /* pk.c in Sources */,
+				02BD21FD21E0EF4E00E023B9 /* mmap_util.c in Sources */,
+				02BD21B021E0EF4E00E023B9 /* pk_wrap.c in Sources */,
+				02BD21AD21E0EF4E00E023B9 /* md4.c in Sources */,
+				02BD21C821E0EF4E00E023B9 /* havege.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		02BD1F5321E0BCBB00E023B9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		02BD1F5421E0BCBB00E023B9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		02BD1F5621E0BCBB00E023B9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = ../../Logan/mbedtls/include/;
+				INFOPLIST_FILE = LoganSwift/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.hanguang.app.LoganSwift;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_INCLUDE_PATHS = "${SRCROOT}/../../Logan/Clogan/**";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		02BD1F5721E0BCBB00E023B9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREPROCESSOR_DEFINITIONS = "";
+				HEADER_SEARCH_PATHS = ../../Logan/mbedtls/include/;
+				INFOPLIST_FILE = LoganSwift/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.hanguang.app.LoganSwift;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_INCLUDE_PATHS = "${SRCROOT}/../../Logan/Clogan/**";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		02BD1F4721E0BCBB00E023B9 /* Build configuration list for PBXProject "LoganSwift" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				02BD1F5321E0BCBB00E023B9 /* Debug */,
+				02BD1F5421E0BCBB00E023B9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		02BD1F5521E0BCBB00E023B9 /* Build configuration list for PBXNativeTarget "LoganSwift" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				02BD1F5621E0BCBB00E023B9 /* Debug */,
+				02BD1F5721E0BCBB00E023B9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 02BD1F4421E0BCBB00E023B9 /* Project object */;
+}

--- a/Example/LoganSwift/LoganSwift.xcodeproj/project.pbxproj
+++ b/Example/LoganSwift/LoganSwift.xcodeproj/project.pbxproj
@@ -14,6 +14,172 @@
 		026DC45021E3299900163479 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 026DC44E21E3299900163479 /* LaunchScreen.storyboard */; };
 		026DC45621E329FB00163479 /* LoganExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026DC45521E329FB00163479 /* LoganExtension.swift */; };
 		028F962521E33E9A00B1DF4C /* LoganSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02BD1F4D21E0BCBB00E023B9 /* LoganSwift.framework */; };
+		028F96FC21E3826400B1DF4C /* base_util.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD214B21E0EF4D00E023B9 /* base_util.h */; };
+		028F96FD21E3826400B1DF4C /* cmac.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20F621E0EF4D00E023B9 /* cmac.h */; };
+		028F96FE21E3826400B1DF4C /* x509_crt.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20E421E0EF4D00E023B9 /* x509_crt.h */; };
+		028F96FF21E3826400B1DF4C /* aesni.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20E921E0EF4D00E023B9 /* aesni.h */; };
+		028F970021E3826400B1DF4C /* md_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20C521E0EF4D00E023B9 /* md_internal.h */; };
+		028F970121E3826400B1DF4C /* x509.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20C021E0EF4D00E023B9 /* x509.h */; };
+		028F970221E3826400B1DF4C /* version.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20C121E0EF4D00E023B9 /* version.h */; };
+		028F970321E3826400B1DF4C /* x509_csr.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20CC21E0EF4D00E023B9 /* x509_csr.h */; };
+		028F970421E3826400B1DF4C /* ssl_cache.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20F521E0EF4D00E023B9 /* ssl_cache.h */; };
+		028F970521E3826400B1DF4C /* pkcs12.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20DA21E0EF4D00E023B9 /* pkcs12.h */; };
+		028F970621E3826400B1DF4C /* x509_crl.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20EC21E0EF4D00E023B9 /* x509_crl.h */; };
+		028F970721E3826400B1DF4C /* ecdh.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20ED21E0EF4D00E023B9 /* ecdh.h */; };
+		028F970821E3826400B1DF4C /* rsa.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20F121E0EF4D00E023B9 /* rsa.h */; };
+		028F970921E3826400B1DF4C /* pkcs11.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20C721E0EF4D00E023B9 /* pkcs11.h */; };
+		028F970A21E3826400B1DF4C /* sha256.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20D321E0EF4D00E023B9 /* sha256.h */; };
+		028F970B21E3826400B1DF4C /* ctr_drbg.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20EA21E0EF4D00E023B9 /* ctr_drbg.h */; };
+		028F970C21E3826400B1DF4C /* platform.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20F721E0EF4D00E023B9 /* platform.h */; };
+		028F970D21E3826400B1DF4C /* threading.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20CE21E0EF4D00E023B9 /* threading.h */; };
+		028F970E21E3826400B1DF4C /* sha512.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20DC21E0EF4D00E023B9 /* sha512.h */; };
+		028F970F21E3826400B1DF4C /* gcm.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20EF21E0EF4D00E023B9 /* gcm.h */; };
+		028F971021E3826400B1DF4C /* construct_data.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD214E21E0EF4D00E023B9 /* construct_data.h */; };
+		028F971121E3826400B1DF4C /* arc4.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20D221E0EF4D00E023B9 /* arc4.h */; };
+		028F971221E3826400B1DF4C /* logan_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD215521E0EF4D00E023B9 /* logan_config.h */; };
+		028F971321E3826400B1DF4C /* net.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20C321E0EF4D00E023B9 /* net.h */; };
+		028F971421E3826400B1DF4C /* bn_mul.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20DD21E0EF4D00E023B9 /* bn_mul.h */; };
+		028F971521E3826400B1DF4C /* des.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20EB21E0EF4D00E023B9 /* des.h */; };
+		028F971621E3826400B1DF4C /* ssl_ciphersuites.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20F421E0EF4D00E023B9 /* ssl_ciphersuites.h */; };
+		028F971721E3826400B1DF4C /* clogan_core.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD215221E0EF4D00E023B9 /* clogan_core.h */; };
+		028F971821E3826400B1DF4C /* md2.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20BA21E0EF4D00E023B9 /* md2.h */; };
+		028F971921E3826400B1DF4C /* ssl_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20C821E0EF4D00E023B9 /* ssl_internal.h */; };
+		028F971A21E3826400B1DF4C /* camellia.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20E221E0EF4D00E023B9 /* camellia.h */; };
+		028F971B21E3826400B1DF4C /* asn1write.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20FB21E0EF4D00E023B9 /* asn1write.h */; };
+		028F971C21E3826400B1DF4C /* md5.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20D021E0EF4D00E023B9 /* md5.h */; };
+		028F971D21E3826400B1DF4C /* padlock.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20DB21E0EF4D00E023B9 /* padlock.h */; };
+		028F971E21E3826400B1DF4C /* memory_buffer_alloc.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20CB21E0EF4D00E023B9 /* memory_buffer_alloc.h */; };
+		028F971F21E3826400B1DF4C /* cJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD214F21E0EF4D00E023B9 /* cJSON.h */; };
+		028F972021E3826400B1DF4C /* hmac_drbg.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20F221E0EF4D00E023B9 /* hmac_drbg.h */; };
+		028F972121E3826400B1DF4C /* entropy_poll.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20F921E0EF4D00E023B9 /* entropy_poll.h */; };
+		028F972221E3826400B1DF4C /* ripemd160.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20BD21E0EF4D00E023B9 /* ripemd160.h */; };
+		028F972321E3826400B1DF4C /* compat-1.3.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20CF21E0EF4D00E023B9 /* compat-1.3.h */; };
+		028F972421E3826400B1DF4C /* base64.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20C621E0EF4D00E023B9 /* base64.h */; };
+		028F972521E3826400B1DF4C /* bignum.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20F821E0EF4D00E023B9 /* bignum.h */; };
+		028F972621E3826400B1DF4C /* directory_util.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD215D21E0EF4D00E023B9 /* directory_util.h */; };
+		028F972721E3826400B1DF4C /* platform_time.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20E121E0EF4D00E023B9 /* platform_time.h */; };
+		028F972821E3826400B1DF4C /* cipher_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20C421E0EF4D00E023B9 /* cipher_internal.h */; };
+		028F972921E3826400B1DF4C /* net_sockets.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20D821E0EF4D00E023B9 /* net_sockets.h */; };
+		028F972A21E3826400B1DF4C /* pkcs5.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20BC21E0EF4D00E023B9 /* pkcs5.h */; };
+		028F972B21E3826400B1DF4C /* check_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20B821E0EF4D00E023B9 /* check_config.h */; };
+		028F972C21E3826400B1DF4C /* blowfish.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20BE21E0EF4D00E023B9 /* blowfish.h */; };
+		028F972D21E3826400B1DF4C /* LoganSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD1F5021E0BCBB00E023B9 /* LoganSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		028F972E21E3826400B1DF4C /* debug.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20BF21E0EF4D00E023B9 /* debug.h */; };
+		028F972F21E3826400B1DF4C /* ecdsa.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20D421E0EF4D00E023B9 /* ecdsa.h */; };
+		028F973021E3826400B1DF4C /* ssl_cookie.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20E721E0EF4D00E023B9 /* ssl_cookie.h */; };
+		028F973121E3826400B1DF4C /* zlib_util.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD214A21E0EF4D00E023B9 /* zlib_util.h */; };
+		028F973221E3826400B1DF4C /* asn1.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20C921E0EF4D00E023B9 /* asn1.h */; };
+		028F973321E3826400B1DF4C /* dhm.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20E821E0EF4D00E023B9 /* dhm.h */; };
+		028F973421E3826400B1DF4C /* oid.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20BB21E0EF4D00E023B9 /* oid.h */; };
+		028F973521E3826400B1DF4C /* ecp.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20C221E0EF4D00E023B9 /* ecp.h */; };
+		028F973621E3826400B1DF4C /* pem.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20B721E0EF4D00E023B9 /* pem.h */; };
+		028F973721E3826400B1DF4C /* md4.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20E321E0EF4D00E023B9 /* md4.h */; };
+		028F973821E3826400B1DF4C /* mmap_util.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD216021E0EF4D00E023B9 /* mmap_util.h */; };
+		028F973921E3826400B1DF4C /* ccm.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20FC21E0EF4D00E023B9 /* ccm.h */; };
+		028F973A21E3826400B1DF4C /* aes.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20E521E0EF4D00E023B9 /* aes.h */; };
+		028F973B21E3826400B1DF4C /* json_util.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD215421E0EF4D00E023B9 /* json_util.h */; };
+		028F973C21E3826400B1DF4C /* md.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20D521E0EF4D00E023B9 /* md.h */; };
+		028F973D21E3826400B1DF4C /* pk.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20DE21E0EF4D00E023B9 /* pk.h */; };
+		028F973E21E3826400B1DF4C /* error.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20B921E0EF4D00E023B9 /* error.h */; };
+		028F973F21E3826400B1DF4C /* xtea.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20CD21E0EF4D00E023B9 /* xtea.h */; };
+		028F974021E3826400B1DF4C /* timing.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20D121E0EF4D00E023B9 /* timing.h */; };
+		028F974121E3826400B1DF4C /* entropy.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20D921E0EF4D00E023B9 /* entropy.h */; };
+		028F974221E3826400B1DF4C /* console_util.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD215A21E0EF4D00E023B9 /* console_util.h */; };
+		028F974321E3826400B1DF4C /* havege.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20FA21E0EF4D00E023B9 /* havege.h */; };
+		028F974421E3826400B1DF4C /* aes_util.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD215121E0EF4D00E023B9 /* aes_util.h */; };
+		028F974521E3826400B1DF4C /* pk_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20E621E0EF4D00E023B9 /* pk_internal.h */; };
+		028F974621E3826400B1DF4C /* ecp_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20DF21E0EF4D00E023B9 /* ecp_internal.h */; };
+		028F974721E3826400B1DF4C /* sha1.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20EE21E0EF4D00E023B9 /* sha1.h */; };
+		028F974821E3826400B1DF4C /* config.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20CA21E0EF4D00E023B9 /* config.h */; };
+		028F974921E3826400B1DF4C /* ecjpake.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20D721E0EF4D00E023B9 /* ecjpake.h */; };
+		028F974A21E3826400B1DF4C /* ssl.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20E021E0EF4D00E023B9 /* ssl.h */; };
+		028F974B21E3826400B1DF4C /* certs.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20F021E0EF4D00E023B9 /* certs.h */; };
+		028F974C21E3826400B1DF4C /* clogan_status.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD215C21E0EF4D00E023B9 /* clogan_status.h */; };
+		028F974D21E3826400B1DF4C /* cipher.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20D621E0EF4D00E023B9 /* cipher.h */; };
+		028F974E21E3826400B1DF4C /* ssl_ticket.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20F321E0EF4D00E023B9 /* ssl_ticket.h */; };
+		028F975021E3826400B1DF4C /* camellia.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210421E0EF4D00E023B9 /* camellia.c */; };
+		028F975121E3826400B1DF4C /* gcm.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211A21E0EF4D00E023B9 /* gcm.c */; };
+		028F975221E3826400B1DF4C /* pkcs11.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213221E0EF4D00E023B9 /* pkcs11.c */; };
+		028F975321E3826400B1DF4C /* asn1write.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211C21E0EF4D00E023B9 /* asn1write.c */; };
+		028F975421E3826400B1DF4C /* cipher.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD214721E0EF4D00E023B9 /* cipher.c */; };
+		028F975521E3826400B1DF4C /* net_sockets.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD214321E0EF4D00E023B9 /* net_sockets.c */; };
+		028F975621E3826400B1DF4C /* certs.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211821E0EF4D00E023B9 /* certs.c */; };
+		028F975721E3826400B1DF4C /* version_features.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211F21E0EF4D00E023B9 /* version_features.c */; };
+		028F975821E3826400B1DF4C /* x509_crt.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210021E0EF4D00E023B9 /* x509_crt.c */; };
+		028F975921E3826400B1DF4C /* cJSON.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD215821E0EF4D00E023B9 /* cJSON.c */; };
+		028F975A21E3826400B1DF4C /* ssl_ticket.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211621E0EF4D00E023B9 /* ssl_ticket.c */; };
+		028F975B21E3826400B1DF4C /* ecdsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD214821E0EF4D00E023B9 /* ecdsa.c */; };
+		028F975C21E3826400B1DF4C /* ctr_drbg.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210E21E0EF4D00E023B9 /* ctr_drbg.c */; };
+		028F975D21E3826400B1DF4C /* error.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212E21E0EF4D00E023B9 /* error.c */; };
+		028F975E21E3826400B1DF4C /* memory_buffer_alloc.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213421E0EF4D00E023B9 /* memory_buffer_alloc.c */; };
+		028F975F21E3826400B1DF4C /* clogan_core.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD216121E0EF4D00E023B9 /* clogan_core.c */; };
+		028F976021E3826400B1DF4C /* base64.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213321E0EF4D00E023B9 /* base64.c */; };
+		028F976121E3826400B1DF4C /* directory_util.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD215021E0EF4D00E023B9 /* directory_util.c */; };
+		028F976221E3826400B1DF4C /* md2.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212F21E0EF4D00E023B9 /* md2.c */; };
+		028F976321E3826400B1DF4C /* padlock.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD214021E0EF4D00E023B9 /* padlock.c */; };
+		028F976421E3826400B1DF4C /* ecjpake.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD214621E0EF4D00E023B9 /* ecjpake.c */; };
+		028F976521E3826400B1DF4C /* x509.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213721E0EF4D00E023B9 /* x509.c */; };
+		028F976621E3826400B1DF4C /* md.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD214521E0EF4D00E023B9 /* md.c */; };
+		028F976721E3826400B1DF4C /* dhm.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211021E0EF4D00E023B9 /* dhm.c */; };
+		028F976821E3826400B1DF4C /* ssl_cache.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211121E0EF4D00E023B9 /* ssl_cache.c */; };
+		028F976921E3826400B1DF4C /* version.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213621E0EF4D00E023B9 /* version.c */; };
+		028F976A21E3826400B1DF4C /* blowfish.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212921E0EF4D00E023B9 /* blowfish.c */; };
+		028F976B21E3826400B1DF4C /* threading.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213F21E0EF4D00E023B9 /* threading.c */; };
+		028F976C21E3826400B1DF4C /* ccm.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211E21E0EF4D00E023B9 /* ccm.c */; };
+		028F976D21E3826400B1DF4C /* sha1.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211B21E0EF4D00E023B9 /* sha1.c */; };
+		028F976E21E3826400B1DF4C /* entropy_poll.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212021E0EF4D00E023B9 /* entropy_poll.c */; };
+		028F976F21E3826400B1DF4C /* LoganSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BD20B121E0E6A400E023B9 /* LoganSwift.swift */; };
+		028F977021E3826400B1DF4C /* construct_data.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD215921E0EF4D00E023B9 /* construct_data.c */; };
+		028F977121E3826400B1DF4C /* console_util.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD214D21E0EF4D00E023B9 /* console_util.c */; };
+		028F977221E3826400B1DF4C /* ecp_curves.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213921E0EF4D00E023B9 /* ecp_curves.c */; };
+		028F977321E3826400B1DF4C /* pkcs12.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD214121E0EF4D00E023B9 /* pkcs12.c */; };
+		028F977421E3826400B1DF4C /* xtea.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213D21E0EF4D00E023B9 /* xtea.c */; };
+		028F977521E3826400B1DF4C /* pkparse.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212521E0EF4D00E023B9 /* pkparse.c */; };
+		028F977621E3826400B1DF4C /* json_util.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD215F21E0EF4D00E023B9 /* json_util.c */; };
+		028F977721E3826400B1DF4C /* rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211521E0EF4D00E023B9 /* rsa.c */; };
+		028F977821E3826400B1DF4C /* arc4.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213B21E0EF4D00E023B9 /* arc4.c */; };
+		028F977921E3826400B1DF4C /* x509write_crt.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213E21E0EF4D00E023B9 /* x509write_crt.c */; };
+		028F977A21E3826400B1DF4C /* zlib_util.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD215721E0EF4D00E023B9 /* zlib_util.c */; };
+		028F977B21E3826400B1DF4C /* x509_create.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD20FF21E0EF4D00E023B9 /* x509_create.c */; };
+		028F977C21E3826400B1DF4C /* hmac_drbg.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211421E0EF4D00E023B9 /* hmac_drbg.c */; };
+		028F977D21E3826400B1DF4C /* des.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210C21E0EF4D00E023B9 /* des.c */; };
+		028F977E21E3826400B1DF4C /* x509_csr.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213121E0EF4D00E023B9 /* x509_csr.c */; };
+		028F977F21E3826400B1DF4C /* md5.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213A21E0EF4D00E023B9 /* md5.c */; };
+		028F978021E3826400B1DF4C /* aes.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210121E0EF4D00E023B9 /* aes.c */; };
+		028F978121E3826400B1DF4C /* timing.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213C21E0EF4D00E023B9 /* timing.c */; };
+		028F978221E3826400B1DF4C /* pem.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212B21E0EF4D00E023B9 /* pem.c */; };
+		028F978321E3826400B1DF4C /* oid.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212D21E0EF4D00E023B9 /* oid.c */; };
+		028F978421E3826400B1DF4C /* entropy.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD214221E0EF4D00E023B9 /* entropy.c */; };
+		028F978521E3826400B1DF4C /* cipher_wrap.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210B21E0EF4D00E023B9 /* cipher_wrap.c */; };
+		028F978621E3826400B1DF4C /* ecp.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213521E0EF4D00E023B9 /* ecp.c */; };
+		028F978721E3826400B1DF4C /* platform.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212221E0EF4D00E023B9 /* platform.c */; };
+		028F978821E3826400B1DF4C /* cmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212321E0EF4D00E023B9 /* cmac.c */; };
+		028F978921E3826400B1DF4C /* base_util.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD215621E0EF4D00E023B9 /* base_util.c */; };
+		028F978A21E3826400B1DF4C /* aesni.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210F21E0EF4D00E023B9 /* aesni.c */; };
+		028F978B21E3826400B1DF4C /* bignum.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212421E0EF4D00E023B9 /* bignum.c */; };
+		028F978C21E3826400B1DF4C /* asn1parse.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211721E0EF4D00E023B9 /* asn1parse.c */; };
+		028F978D21E3826400B1DF4C /* sha512.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD214421E0EF4D00E023B9 /* sha512.c */; };
+		028F978E21E3826400B1DF4C /* x509_crl.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210A21E0EF4D00E023B9 /* x509_crl.c */; };
+		028F978F21E3826400B1DF4C /* aes_util.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD215E21E0EF4D00E023B9 /* aes_util.c */; };
+		028F979021E3826400B1DF4C /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211321E0EF4D00E023B9 /* Makefile */; };
+		028F979121E3826400B1DF4C /* ssl_ciphersuites.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211221E0EF4D00E023B9 /* ssl_ciphersuites.c */; };
+		028F979221E3826400B1DF4C /* ripemd160.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212721E0EF4D00E023B9 /* ripemd160.c */; };
+		028F979321E3826400B1DF4C /* ecdh.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210821E0EF4D00E023B9 /* ecdh.c */; };
+		028F979421E3826400B1DF4C /* sha256.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213821E0EF4D00E023B9 /* sha256.c */; };
+		028F979521E3826400B1DF4C /* ssl_cli.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212821E0EF4D00E023B9 /* ssl_cli.c */; };
+		028F979621E3826400B1DF4C /* ssl_tls.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210921E0EF4D00E023B9 /* ssl_tls.c */; };
+		028F979721E3826400B1DF4C /* pkcs5.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212A21E0EF4D00E023B9 /* pkcs5.c */; };
+		028F979821E3826400B1DF4C /* debug.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212621E0EF4D00E023B9 /* debug.c */; };
+		028F979921E3826400B1DF4C /* ssl_srv.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210321E0EF4D00E023B9 /* ssl_srv.c */; };
+		028F979A21E3826400B1DF4C /* md_wrap.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD213021E0EF4D00E023B9 /* md_wrap.c */; };
+		028F979B21E3826400B1DF4C /* ssl_cookie.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210D21E0EF4D00E023B9 /* ssl_cookie.c */; };
+		028F979C21E3826400B1DF4C /* pkwrite.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211921E0EF4D00E023B9 /* pkwrite.c */; };
+		028F979D21E3826400B1DF4C /* x509write_csr.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD212121E0EF4D00E023B9 /* x509write_csr.c */; };
+		028F979E21E3826400B1DF4C /* pk.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210621E0EF4D00E023B9 /* pk.c */; };
+		028F979F21E3826400B1DF4C /* mmap_util.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD215321E0EF4D00E023B9 /* mmap_util.c */; };
+		028F97A021E3826400B1DF4C /* pk_wrap.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210521E0EF4D00E023B9 /* pk_wrap.c */; };
+		028F97A121E3826400B1DF4C /* md4.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD210221E0EF4D00E023B9 /* md4.c */; };
+		028F97A221E3826400B1DF4C /* havege.c in Sources */ = {isa = PBXBuildFile; fileRef = 02BD211D21E0EF4D00E023B9 /* havege.c */; };
 		02BD1F5221E0BCBB00E023B9 /* LoganSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD1F5021E0BCBB00E023B9 /* LoganSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		02BD20B221E0E6A400E023B9 /* LoganSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BD20B121E0E6A400E023B9 /* LoganSwift.swift */; };
 		02BD216321E0EF4E00E023B9 /* pem.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BD20B721E0EF4D00E023B9 /* pem.h */; };
@@ -191,6 +357,7 @@
 		026DC44F21E3299900163479 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		026DC45121E3299900163479 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		026DC45521E329FB00163479 /* LoganExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoganExtension.swift; sourceTree = "<group>"; };
+		028F97A821E3826400B1DF4C /* LoganSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LoganSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		02BD1F4D21E0BCBB00E023B9 /* LoganSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LoganSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		02BD1F5021E0BCBB00E023B9 /* LoganSwift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LoganSwift.h; sourceTree = "<group>"; };
 		02BD1F5121E0BCBB00E023B9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -376,6 +543,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		028F97A321E3826400B1DF4C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		02BD1F4A21E0BCBB00E023B9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -424,6 +598,7 @@
 			children = (
 				02BD1F4D21E0BCBB00E023B9 /* LoganSwift.framework */,
 				026DC44321E3299800163479 /* example.app */,
+				028F97A821E3826400B1DF4C /* LoganSwift.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -651,6 +826,96 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		028F96FB21E3826400B1DF4C /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				028F96FC21E3826400B1DF4C /* base_util.h in Headers */,
+				028F96FD21E3826400B1DF4C /* cmac.h in Headers */,
+				028F96FE21E3826400B1DF4C /* x509_crt.h in Headers */,
+				028F96FF21E3826400B1DF4C /* aesni.h in Headers */,
+				028F970021E3826400B1DF4C /* md_internal.h in Headers */,
+				028F970121E3826400B1DF4C /* x509.h in Headers */,
+				028F970221E3826400B1DF4C /* version.h in Headers */,
+				028F970321E3826400B1DF4C /* x509_csr.h in Headers */,
+				028F970421E3826400B1DF4C /* ssl_cache.h in Headers */,
+				028F970521E3826400B1DF4C /* pkcs12.h in Headers */,
+				028F970621E3826400B1DF4C /* x509_crl.h in Headers */,
+				028F970721E3826400B1DF4C /* ecdh.h in Headers */,
+				028F970821E3826400B1DF4C /* rsa.h in Headers */,
+				028F970921E3826400B1DF4C /* pkcs11.h in Headers */,
+				028F970A21E3826400B1DF4C /* sha256.h in Headers */,
+				028F970B21E3826400B1DF4C /* ctr_drbg.h in Headers */,
+				028F970C21E3826400B1DF4C /* platform.h in Headers */,
+				028F970D21E3826400B1DF4C /* threading.h in Headers */,
+				028F970E21E3826400B1DF4C /* sha512.h in Headers */,
+				028F970F21E3826400B1DF4C /* gcm.h in Headers */,
+				028F971021E3826400B1DF4C /* construct_data.h in Headers */,
+				028F971121E3826400B1DF4C /* arc4.h in Headers */,
+				028F971221E3826400B1DF4C /* logan_config.h in Headers */,
+				028F971321E3826400B1DF4C /* net.h in Headers */,
+				028F971421E3826400B1DF4C /* bn_mul.h in Headers */,
+				028F971521E3826400B1DF4C /* des.h in Headers */,
+				028F971621E3826400B1DF4C /* ssl_ciphersuites.h in Headers */,
+				028F971721E3826400B1DF4C /* clogan_core.h in Headers */,
+				028F971821E3826400B1DF4C /* md2.h in Headers */,
+				028F971921E3826400B1DF4C /* ssl_internal.h in Headers */,
+				028F971A21E3826400B1DF4C /* camellia.h in Headers */,
+				028F971B21E3826400B1DF4C /* asn1write.h in Headers */,
+				028F971C21E3826400B1DF4C /* md5.h in Headers */,
+				028F971D21E3826400B1DF4C /* padlock.h in Headers */,
+				028F971E21E3826400B1DF4C /* memory_buffer_alloc.h in Headers */,
+				028F971F21E3826400B1DF4C /* cJSON.h in Headers */,
+				028F972021E3826400B1DF4C /* hmac_drbg.h in Headers */,
+				028F972121E3826400B1DF4C /* entropy_poll.h in Headers */,
+				028F972221E3826400B1DF4C /* ripemd160.h in Headers */,
+				028F972321E3826400B1DF4C /* compat-1.3.h in Headers */,
+				028F972421E3826400B1DF4C /* base64.h in Headers */,
+				028F972521E3826400B1DF4C /* bignum.h in Headers */,
+				028F972621E3826400B1DF4C /* directory_util.h in Headers */,
+				028F972721E3826400B1DF4C /* platform_time.h in Headers */,
+				028F972821E3826400B1DF4C /* cipher_internal.h in Headers */,
+				028F972921E3826400B1DF4C /* net_sockets.h in Headers */,
+				028F972A21E3826400B1DF4C /* pkcs5.h in Headers */,
+				028F972B21E3826400B1DF4C /* check_config.h in Headers */,
+				028F972C21E3826400B1DF4C /* blowfish.h in Headers */,
+				028F972D21E3826400B1DF4C /* LoganSwift.h in Headers */,
+				028F972E21E3826400B1DF4C /* debug.h in Headers */,
+				028F972F21E3826400B1DF4C /* ecdsa.h in Headers */,
+				028F973021E3826400B1DF4C /* ssl_cookie.h in Headers */,
+				028F973121E3826400B1DF4C /* zlib_util.h in Headers */,
+				028F973221E3826400B1DF4C /* asn1.h in Headers */,
+				028F973321E3826400B1DF4C /* dhm.h in Headers */,
+				028F973421E3826400B1DF4C /* oid.h in Headers */,
+				028F973521E3826400B1DF4C /* ecp.h in Headers */,
+				028F973621E3826400B1DF4C /* pem.h in Headers */,
+				028F973721E3826400B1DF4C /* md4.h in Headers */,
+				028F973821E3826400B1DF4C /* mmap_util.h in Headers */,
+				028F973921E3826400B1DF4C /* ccm.h in Headers */,
+				028F973A21E3826400B1DF4C /* aes.h in Headers */,
+				028F973B21E3826400B1DF4C /* json_util.h in Headers */,
+				028F973C21E3826400B1DF4C /* md.h in Headers */,
+				028F973D21E3826400B1DF4C /* pk.h in Headers */,
+				028F973E21E3826400B1DF4C /* error.h in Headers */,
+				028F973F21E3826400B1DF4C /* xtea.h in Headers */,
+				028F974021E3826400B1DF4C /* timing.h in Headers */,
+				028F974121E3826400B1DF4C /* entropy.h in Headers */,
+				028F974221E3826400B1DF4C /* console_util.h in Headers */,
+				028F974321E3826400B1DF4C /* havege.h in Headers */,
+				028F974421E3826400B1DF4C /* aes_util.h in Headers */,
+				028F974521E3826400B1DF4C /* pk_internal.h in Headers */,
+				028F974621E3826400B1DF4C /* ecp_internal.h in Headers */,
+				028F974721E3826400B1DF4C /* sha1.h in Headers */,
+				028F974821E3826400B1DF4C /* config.h in Headers */,
+				028F974921E3826400B1DF4C /* ecjpake.h in Headers */,
+				028F974A21E3826400B1DF4C /* ssl.h in Headers */,
+				028F974B21E3826400B1DF4C /* certs.h in Headers */,
+				028F974C21E3826400B1DF4C /* clogan_status.h in Headers */,
+				028F974D21E3826400B1DF4C /* cipher.h in Headers */,
+				028F974E21E3826400B1DF4C /* ssl_ticket.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		02BD1F4821E0BCBB00E023B9 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -761,6 +1026,24 @@
 			productReference = 026DC44321E3299800163479 /* example.app */;
 			productType = "com.apple.product-type.application";
 		};
+		028F96FA21E3826400B1DF4C /* LoganSwift macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 028F97A521E3826400B1DF4C /* Build configuration list for PBXNativeTarget "LoganSwift macOS" */;
+			buildPhases = (
+				028F96FB21E3826400B1DF4C /* Headers */,
+				028F974F21E3826400B1DF4C /* Sources */,
+				028F97A321E3826400B1DF4C /* Frameworks */,
+				028F97A421E3826400B1DF4C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "LoganSwift macOS";
+			productName = LoganSwift;
+			productReference = 028F97A821E3826400B1DF4C /* LoganSwift.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		02BD1F4C21E0BCBB00E023B9 /* LoganSwift */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 02BD1F5521E0BCBB00E023B9 /* Build configuration list for PBXNativeTarget "LoganSwift" */;
@@ -812,6 +1095,7 @@
 			projectRoot = "";
 			targets = (
 				02BD1F4C21E0BCBB00E023B9 /* LoganSwift */,
+				028F96FA21E3826400B1DF4C /* LoganSwift macOS */,
 				026DC44221E3299800163479 /* example */,
 			);
 		};
@@ -825,6 +1109,13 @@
 				026DC45021E3299900163479 /* LaunchScreen.storyboard in Resources */,
 				026DC44D21E3299900163479 /* Assets.xcassets in Resources */,
 				026DC44B21E3299800163479 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		028F97A421E3826400B1DF4C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -845,6 +1136,96 @@
 				026DC45621E329FB00163479 /* LoganExtension.swift in Sources */,
 				026DC44821E3299800163479 /* ViewController.swift in Sources */,
 				026DC44621E3299800163479 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		028F974F21E3826400B1DF4C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				028F975021E3826400B1DF4C /* camellia.c in Sources */,
+				028F975121E3826400B1DF4C /* gcm.c in Sources */,
+				028F975221E3826400B1DF4C /* pkcs11.c in Sources */,
+				028F975321E3826400B1DF4C /* asn1write.c in Sources */,
+				028F975421E3826400B1DF4C /* cipher.c in Sources */,
+				028F975521E3826400B1DF4C /* net_sockets.c in Sources */,
+				028F975621E3826400B1DF4C /* certs.c in Sources */,
+				028F975721E3826400B1DF4C /* version_features.c in Sources */,
+				028F975821E3826400B1DF4C /* x509_crt.c in Sources */,
+				028F975921E3826400B1DF4C /* cJSON.c in Sources */,
+				028F975A21E3826400B1DF4C /* ssl_ticket.c in Sources */,
+				028F975B21E3826400B1DF4C /* ecdsa.c in Sources */,
+				028F975C21E3826400B1DF4C /* ctr_drbg.c in Sources */,
+				028F975D21E3826400B1DF4C /* error.c in Sources */,
+				028F975E21E3826400B1DF4C /* memory_buffer_alloc.c in Sources */,
+				028F975F21E3826400B1DF4C /* clogan_core.c in Sources */,
+				028F976021E3826400B1DF4C /* base64.c in Sources */,
+				028F976121E3826400B1DF4C /* directory_util.c in Sources */,
+				028F976221E3826400B1DF4C /* md2.c in Sources */,
+				028F976321E3826400B1DF4C /* padlock.c in Sources */,
+				028F976421E3826400B1DF4C /* ecjpake.c in Sources */,
+				028F976521E3826400B1DF4C /* x509.c in Sources */,
+				028F976621E3826400B1DF4C /* md.c in Sources */,
+				028F976721E3826400B1DF4C /* dhm.c in Sources */,
+				028F976821E3826400B1DF4C /* ssl_cache.c in Sources */,
+				028F976921E3826400B1DF4C /* version.c in Sources */,
+				028F976A21E3826400B1DF4C /* blowfish.c in Sources */,
+				028F976B21E3826400B1DF4C /* threading.c in Sources */,
+				028F976C21E3826400B1DF4C /* ccm.c in Sources */,
+				028F976D21E3826400B1DF4C /* sha1.c in Sources */,
+				028F976E21E3826400B1DF4C /* entropy_poll.c in Sources */,
+				028F976F21E3826400B1DF4C /* LoganSwift.swift in Sources */,
+				028F977021E3826400B1DF4C /* construct_data.c in Sources */,
+				028F977121E3826400B1DF4C /* console_util.c in Sources */,
+				028F977221E3826400B1DF4C /* ecp_curves.c in Sources */,
+				028F977321E3826400B1DF4C /* pkcs12.c in Sources */,
+				028F977421E3826400B1DF4C /* xtea.c in Sources */,
+				028F977521E3826400B1DF4C /* pkparse.c in Sources */,
+				028F977621E3826400B1DF4C /* json_util.c in Sources */,
+				028F977721E3826400B1DF4C /* rsa.c in Sources */,
+				028F977821E3826400B1DF4C /* arc4.c in Sources */,
+				028F977921E3826400B1DF4C /* x509write_crt.c in Sources */,
+				028F977A21E3826400B1DF4C /* zlib_util.c in Sources */,
+				028F977B21E3826400B1DF4C /* x509_create.c in Sources */,
+				028F977C21E3826400B1DF4C /* hmac_drbg.c in Sources */,
+				028F977D21E3826400B1DF4C /* des.c in Sources */,
+				028F977E21E3826400B1DF4C /* x509_csr.c in Sources */,
+				028F977F21E3826400B1DF4C /* md5.c in Sources */,
+				028F978021E3826400B1DF4C /* aes.c in Sources */,
+				028F978121E3826400B1DF4C /* timing.c in Sources */,
+				028F978221E3826400B1DF4C /* pem.c in Sources */,
+				028F978321E3826400B1DF4C /* oid.c in Sources */,
+				028F978421E3826400B1DF4C /* entropy.c in Sources */,
+				028F978521E3826400B1DF4C /* cipher_wrap.c in Sources */,
+				028F978621E3826400B1DF4C /* ecp.c in Sources */,
+				028F978721E3826400B1DF4C /* platform.c in Sources */,
+				028F978821E3826400B1DF4C /* cmac.c in Sources */,
+				028F978921E3826400B1DF4C /* base_util.c in Sources */,
+				028F978A21E3826400B1DF4C /* aesni.c in Sources */,
+				028F978B21E3826400B1DF4C /* bignum.c in Sources */,
+				028F978C21E3826400B1DF4C /* asn1parse.c in Sources */,
+				028F978D21E3826400B1DF4C /* sha512.c in Sources */,
+				028F978E21E3826400B1DF4C /* x509_crl.c in Sources */,
+				028F978F21E3826400B1DF4C /* aes_util.c in Sources */,
+				028F979021E3826400B1DF4C /* Makefile in Sources */,
+				028F979121E3826400B1DF4C /* ssl_ciphersuites.c in Sources */,
+				028F979221E3826400B1DF4C /* ripemd160.c in Sources */,
+				028F979321E3826400B1DF4C /* ecdh.c in Sources */,
+				028F979421E3826400B1DF4C /* sha256.c in Sources */,
+				028F979521E3826400B1DF4C /* ssl_cli.c in Sources */,
+				028F979621E3826400B1DF4C /* ssl_tls.c in Sources */,
+				028F979721E3826400B1DF4C /* pkcs5.c in Sources */,
+				028F979821E3826400B1DF4C /* debug.c in Sources */,
+				028F979921E3826400B1DF4C /* ssl_srv.c in Sources */,
+				028F979A21E3826400B1DF4C /* md_wrap.c in Sources */,
+				028F979B21E3826400B1DF4C /* ssl_cookie.c in Sources */,
+				028F979C21E3826400B1DF4C /* pkwrite.c in Sources */,
+				028F979D21E3826400B1DF4C /* x509write_csr.c in Sources */,
+				028F979E21E3826400B1DF4C /* pk.c in Sources */,
+				028F979F21E3826400B1DF4C /* mmap_util.c in Sources */,
+				028F97A021E3826400B1DF4C /* pk_wrap.c in Sources */,
+				028F97A121E3826400B1DF4C /* md4.c in Sources */,
+				028F97A221E3826400B1DF4C /* havege.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -991,6 +1372,73 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		028F97A621E3826400B1DF4C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = ../../Logan/mbedtls/include/;
+				INFOPLIST_FILE = LoganSwift/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hanguang.app.LoganSwift;
+				PRODUCT_NAME = LoganSwift;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_INCLUDE_PATHS = "${SRCROOT}/../../Logan/Clogan/**";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALID_ARCHS = "i386 x86_64";
+			};
+			name = Debug;
+		};
+		028F97A721E3826400B1DF4C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREPROCESSOR_DEFINITIONS = "";
+				HEADER_SEARCH_PATHS = ../../Logan/mbedtls/include/;
+				INFOPLIST_FILE = LoganSwift/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hanguang.app.LoganSwift;
+				PRODUCT_NAME = LoganSwift;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_INCLUDE_PATHS = "${SRCROOT}/../../Logan/Clogan/**";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Release;
 		};
@@ -1183,6 +1631,15 @@
 			buildConfigurations = (
 				026DC45221E3299900163479 /* Debug */,
 				026DC45321E3299900163479 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		028F97A521E3826400B1DF4C /* Build configuration list for PBXNativeTarget "LoganSwift macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				028F97A621E3826400B1DF4C /* Debug */,
+				028F97A721E3826400B1DF4C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/LoganSwift/LoganSwift.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/LoganSwift/LoganSwift.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:LoganSwift.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Example/LoganSwift/LoganSwift.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/LoganSwift/LoganSwift.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/LoganSwift/LoganSwift.xcodeproj/xcshareddata/xcschemes/LoganSwift macOS.xcscheme
+++ b/Example/LoganSwift/LoganSwift.xcodeproj/xcshareddata/xcschemes/LoganSwift macOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "028F96FA21E3826400B1DF4C"
+               BuildableName = "LoganSwift.framework"
+               BlueprintName = "LoganSwift macOS"
+               ReferencedContainer = "container:LoganSwift.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "028F96FA21E3826400B1DF4C"
+            BuildableName = "LoganSwift.framework"
+            BlueprintName = "LoganSwift macOS"
+            ReferencedContainer = "container:LoganSwift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "028F96FA21E3826400B1DF4C"
+            BuildableName = "LoganSwift.framework"
+            BlueprintName = "LoganSwift macOS"
+            ReferencedContainer = "container:LoganSwift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/LoganSwift/LoganSwift.xcodeproj/xcshareddata/xcschemes/LoganSwift.xcscheme
+++ b/Example/LoganSwift/LoganSwift.xcodeproj/xcshareddata/xcschemes/LoganSwift.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "02BD1F4C21E0BCBB00E023B9"
+               BuildableName = "LoganSwift.framework"
+               BlueprintName = "LoganSwift"
+               ReferencedContainer = "container:LoganSwift.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "02BD1F4C21E0BCBB00E023B9"
+            BuildableName = "LoganSwift.framework"
+            BlueprintName = "LoganSwift"
+            ReferencedContainer = "container:LoganSwift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "02BD1F4C21E0BCBB00E023B9"
+            BuildableName = "LoganSwift.framework"
+            BlueprintName = "LoganSwift"
+            ReferencedContainer = "container:LoganSwift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/LoganSwift/LoganSwift/Info.plist
+++ b/Example/LoganSwift/LoganSwift/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/Example/LoganSwift/LoganSwift/LoganSwift.h
+++ b/Example/LoganSwift/LoganSwift/LoganSwift.h
@@ -6,7 +6,7 @@
 //  Copyright © 2019 hanguang. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
 //! Project version number for LoganSwift.
 FOUNDATION_EXPORT double LoganSwiftVersionNumber;

--- a/Example/LoganSwift/LoganSwift/LoganSwift.h
+++ b/Example/LoganSwift/LoganSwift/LoganSwift.h
@@ -1,0 +1,19 @@
+//
+//  LoganSwift.h
+//  LoganSwift
+//
+//  Created by Hanguang on 2019/1/5.
+//  Copyright © 2019 hanguang. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for LoganSwift.
+FOUNDATION_EXPORT double LoganSwiftVersionNumber;
+
+//! Project version string for LoganSwift.
+FOUNDATION_EXPORT const unsigned char LoganSwiftVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <LoganSwift/PublicHeader.h>
+
+

--- a/Example/LoganSwift/LoganSwift/LoganSwift.swift
+++ b/Example/LoganSwift/LoganSwift/LoganSwift.swift
@@ -1,0 +1,105 @@
+//
+//  LoganSwift.swift
+//  LoganSwift
+//
+//  Created by Hanguang on 2019/1/5.
+//  Copyright © 2019 hanguang. All rights reserved.
+//
+
+import Foundation
+import Clogan
+
+private let loganLogDirectory: String = {
+    let path = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first! as NSString
+    return path.appendingPathComponent("LoganLoggerv3") as String
+}()
+
+private var LOGANUSEASL = false;
+
+private let AES_KEY: String = "0123456789012345"
+private let AES_IV: String = "0123456789012345"
+private let max_file: Int32 = 10 * 1024 * 1024
+
+public protocol LoganEncryptionProvider {
+    var aesKey: String { get }
+    var aesIv: String { get }
+    var fileSize: Int32 { get }
+}
+
+public extension LoganEncryptionProvider {
+    var aesKey: String {
+        return AES_KEY
+    }
+    
+    var aesIv: String {
+        return AES_IV
+    }
+    
+    var fileSize: Int32 {
+        return max_file
+    }
+}
+
+public typealias FileInfo = (String, Int32)
+
+final public class LoganImpl: LoganEncryptionProvider {
+    private let loganQueue: DispatchQueue = DispatchQueue(label: "com.dianping.logan", qos: .utility)
+    private var lastCheckFreeSpace: TimeInterval = 0
+    private var lastLogDate: String = ""
+    
+    public func log(_ text: String, _ type: UInt) {
+        
+    }
+    
+    public func clearLogs() {
+        
+    }
+    
+    public func allFilesInfo() -> LoganSwift.FileInfo {
+        return ("", 0)
+    }
+    
+    public var currentDate: String {
+        return ""
+    }
+    
+    public func flash() {
+        
+    }
+    
+    public func filePath(date: String, _ closure: @escaping ()->(String)) {
+        
+    }
+    
+    public init() {
+        loganQueue.async { [unowned self] in
+            self.openClib()
+//            [self addNotification];
+//            [self reTemFile];
+        }
+    }
+    
+    public func useASL(_ b: Bool) {
+        LOGANUSEASL = b
+    }
+    
+    public func printClibLog(_ b: Bool) {
+        let result: Int32 = b ? 1 : 0
+        clogan_debug(result)
+    }
+    
+    private func openClib() {
+        let path = (loganLogDirectory as NSString).utf8String
+        clogan_init(path, path, fileSize, aesKey.unsafePointerInt8, aesIv.unsafePointerInt8)
+        clogan_open((currentDate as NSString).utf8String)
+    }
+    
+}
+
+extension String {
+    var unsafePointerInt8: UnsafePointer<Int8> {
+        let data = self.data(using: .utf8)! as NSData
+        return data.bytes.bindMemory(to: Int8.self, capacity: data.length)
+    }
+}
+

--- a/Example/LoganSwift/LoganSwift/LoganSwift.swift
+++ b/Example/LoganSwift/LoganSwift/LoganSwift.swift
@@ -133,7 +133,7 @@ extension LoganImpl {
         var infoDic: FileInfo = [:]
         for path in paths {
             let path = path as NSString
-            guard !path.pathExtension.isEmpty else {
+            guard path.pathExtension.isEmpty else {
                 continue
             }
             
@@ -421,8 +421,9 @@ extension LoganImpl {
         let paths = logFiles()
         for path in paths {
             if path.hasSuffix(".temp") {
+                let filePath = logFilePath(path)
                 do {
-                    try FileManager.default.removeItem(atPath: path)
+                    try FileManager.default.removeItem(atPath: filePath)
                 } catch let error {
                     print(error)
                     continue

--- a/Example/LoganSwift/LoganSwift/LoganSwift.swift
+++ b/Example/LoganSwift/LoganSwift/LoganSwift.swift
@@ -6,27 +6,24 @@
 //  Copyright © 2019 hanguang. All rights reserved.
 //
 
-import Foundation
+#if os(iOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
+
 import Clogan
 
-private let loganLogDirectory: String = {
-    let path = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first! as NSString
-    return path.appendingPathComponent("LoganLoggerv3") as String
-}()
+// MARK: - Public
 
-private var LOGANUSEASL = false;
-
-private let AES_KEY: String = "0123456789012345"
-private let AES_IV: String = "0123456789012345"
-private let max_file: Int32 = 10 * 1024 * 1024
-
-public protocol LoganEncryptionProvider {
+/// Encryption context, such as key, iv and file size
+public protocol LoganEncryptionContext {
     var aesKey: String { get }
     var aesIv: String { get }
     var fileSize: Int32 { get }
 }
 
-public extension LoganEncryptionProvider {
+public extension LoganEncryptionContext {
     var aesKey: String {
         return AES_KEY
     }
@@ -40,42 +37,192 @@ public extension LoganEncryptionProvider {
     }
 }
 
-public typealias FileInfo = (String, Int32)
+public typealias FileInfo = [String: UInt64]
 
-final public class LoganImpl: LoganEncryptionProvider {
-    private let loganQueue: DispatchQueue = DispatchQueue(label: "com.dianping.logan", qos: .utility)
-    private var lastCheckFreeSpace: TimeInterval = 0
-    private var lastLogDate: String = ""
+final public class LoganImpl: LoganEncryptionContext {
     
-    public func log(_ text: String, _ type: UInt) {
+    public func log(_ what: @autoclosure () -> String, _ type: Int32) {
+        let text = what()
+        guard !text.isEmpty else {
+            return
+        }
         
+        let localTime = Date().timeIntervalSince1970*1000
+        let threadName = Thread.current.name as NSString?
+        let threadNumber = getThreadNumber()
+        let isMain = Thread.current.isMainThread
+        let threadNameC = threadName != nil ? (threadName! as NSString) : ("" as NSString)
+        
+        if LOGANUSEASL {
+            printLog(text, type: type)
+        }
+        
+        guard hasFreeSpace() else {
+            return
+        }
+        
+        async { [weak self] in
+            guard let `self` = self else { return }
+            let today = self.currentDate
+            if !self.lastLogDate.isEmpty && self.lastLogDate != today {
+                clogan_flush()
+                clogan_open((today as NSString).utf8String)
+            }
+            self.lastLogDate = today
+            let t = UnsafeMutablePointer<Int8>.init(mutating: (text as NSString).utf8String)
+            let c = UnsafeMutablePointer<Int8>.init(mutating: threadNameC.utf8String)
+            clogan_write(type, t, Int64(localTime), c, Int64(threadNumber), isMain ? 1 : 0)
+        }
     }
     
     public func clearLogs() {
-        
+        async { [weak self] in
+            guard let `self` = self else { return }
+            let paths = self.localFilesArray()
+            for path in paths {
+                do {
+                    try FileManager.default.removeItem(atPath: (loganLogDirectory as NSString).appendingPathComponent(path))
+                } catch let error {
+                    print(error)
+                }
+            }
+        }
     }
     
     public func allFilesInfo() -> LoganSwift.FileInfo {
-        return ("", 0)
+        let paths = localFilesArray()
+        let dateFormatString = "yyyy-MM-dd"
+        var infoDic: FileInfo = [:]
+        for path in paths {
+            let path = path as NSString
+            guard !path.pathExtension.isEmpty else {
+                continue
+            }
+            
+            let dateString = path.substring(to: dateFormatString.count)
+            let gzFileSize = fileSize(path: logFilePath(dateString))
+            infoDic[dateString] = gzFileSize
+        }
+        
+        return infoDic
+    }
+    
+    private func fileSize(path: String) -> UInt64 {
+        guard !path.isEmpty,
+            FileManager.default.fileExists(atPath: path),
+            let fileInfo = try? FileManager.default.attributesOfItem(atPath: path),
+            let size = fileInfo[.size] as? UInt64
+            else {
+                return 0
+        }
+        
+        return size
+        
     }
     
     public var currentDate: String {
-        return ""
+        return dateFormatter.string(from: Date())
     }
     
     public func flash() {
-        
+        async {
+            clogan_flush()
+        }
     }
     
-    public func filePath(date: String, _ closure: @escaping ()->(String)) {
+    public func filePath(date: String, _ closure: @escaping (String) -> ()) {
+        guard !date.isEmpty else {
+            closure("")
+            return
+        }
         
+        var filePath: String? = nil
+        
+        let paths = localFilesArray()
+        if paths.contains(date) {
+            let path = logFilePath(date)
+            if FileManager.default.fileExists(atPath: path) {
+                filePath = path
+            }
+        }
+        
+        guard let uploadFilePath = filePath else {
+            closure("")
+            return
+        }
+        
+        async { [weak self] in
+            guard let `self` = self else { return }
+            if date == self.currentDate {
+                self.todayFilePath(closure)
+            } else {
+                closure(uploadFilePath)
+            }
+        }
     }
     
+    private func todayFilePath(_ closure: (String) -> ()) {
+        flash()
+        
+        var uploadFilePath = self.uploadFilePath(currentDate)
+        let filePath = logFilePath(currentDate)
+        
+        do {
+            try FileManager.default.removeItem(atPath: uploadFilePath)
+        } catch let error {
+            print(error)
+        }
+        
+        do {
+            try FileManager.default.copyItem(atPath: filePath, toPath: uploadFilePath)
+        } catch let error {
+            print(error)
+            uploadFilePath = ""
+        }
+        
+        closure(uploadFilePath)
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    private func logFilePath(_ date: String) -> String {
+        return (loganLogDirectory as NSString).appendingPathComponent(date)
+    }
+
     public init() {
-        loganQueue.async { [unowned self] in
+        loganQueue = DispatchQueue(label: "com.dianping.logan", qos: .utility)
+        loganQueue.setSpecific(key: QueueSpecificKey, value: specific)
+        
+        async { [unowned self] in
             self.openClib()
-//            [self addNotification];
-//            [self reTemFile];
+            self.addNotification()
+            self.removeTempFile()
+        }
+    }
+    
+    public func isCurrent() -> Bool {
+        if DispatchQueue.getSpecific(key: QueueSpecificKey) === self.specific {
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    public func async(_ f: @escaping () -> Void) {
+        if self.isCurrent() {
+            f()
+        } else {
+            loganQueue.async(execute: f)
+        }
+    }
+    
+    public func sync(_ f: () -> Void) {
+        if self.isCurrent() {
+            f()
+        } else {
+            loganQueue.sync(execute: f)
         }
     }
     
@@ -94,6 +241,161 @@ final public class LoganImpl: LoganEncryptionProvider {
         clogan_open((currentDate as NSString).utf8String)
     }
     
+    private func addNotification() {
+        if Bundle.main.bundlePath.hasSuffix(".appex") {
+            return
+        }
+        
+        #if os(iOS)
+        NotificationCenter.default.addObserver(self, selector: #selector(appWillEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(appDidEnterBackground), name: UIApplication.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(appWillTerminate), name: UIApplication.willTerminateNotification, object: nil)
+        #elseif os(macOS)
+        NotificationCenter.default.addObserver(self, selector: #selector(appWillEnterForeground), name: NSApplication.willEnterForegroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(appDidEnterBackground), name: NSApplication.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(appWillTerminate), name: NSApplication.willTerminateNotification, object: nil)
+        #endif
+    }
+    
+    @objc private func appWillResignActive() {
+        flash()
+    }
+    
+    @objc private func appDidEnterBackground() {
+        flash()
+    }
+    
+    @objc private func appWillEnterForeground() {
+        flash()
+    }
+    
+    @objc private func appWillTerminate() {
+        flash()
+    }
+    
+    private func removeTempFile() {
+        let paths = localFilesArray()
+        for path in paths {
+            if path.hasSuffix(".temp") {
+                do {
+                    try FileManager.default.removeItem(atPath: path)
+                } catch let error {
+                    print(error)
+                }
+            }
+        }
+    }
+    
+    private func uploadFilePath(_ date: String) -> String {
+        return (loganLogDirectory as NSString).appendingPathComponent(date+".temp")
+    }
+    
+    private func localFilesArray() -> [String] {
+        guard let paths = try? FileManager.default.contentsOfDirectory(atPath: loganLogDirectory).filter({ (string) -> Bool in
+            return string.contains("-")
+        }).sorted() else {
+            return []
+        }
+        return paths
+    }
+    
+    
+    private func getThreadNumber() -> Int {
+        let description = Thread.current.description as NSString
+        let beginRange = description.range(of: "{")
+        let endRange = description.range(of: "}")
+        
+        guard beginRange.location != NSNotFound && endRange.location != NSNotFound else {
+            return -1
+        }
+        
+        let length = endRange.location-beginRange.location-1
+        guard length > 0 else {
+            return -1
+        }
+        
+        let keyRange = NSRange(location: beginRange.location+1, length: length)
+        guard keyRange.location != NSNotFound else {
+            return -1
+        }
+        
+        if description.length > (keyRange.location+keyRange.length) {
+            let keyPairs = description.substring(with: keyRange)
+            let keyValuePairs = keyPairs.components(separatedBy: ",")
+            for keyValuePair in keyValuePairs {
+                let components = keyValuePair.components(separatedBy: "=")
+                if !components.isEmpty {
+                    var key = components.first!
+                    key = key.trimmingCharacters(in: .whitespaces)
+                    if (key == "num" || key == "number") && components.count > 1 {
+                        return Int(components[1]) ?? -1
+                    }
+                }
+            }
+        }
+        
+        return -1
+    }
+    
+    // MARK: -
+    private var specific = NSObject()
+    private let loganQueue: DispatchQueue
+    private var lastCheckFreeSpace: TimeInterval = 0
+    private var lastLogDate: String = ""
+    //    private var dtime: time_t = -1
+    
+    private func printLog(_ what: @autoclosure () -> String, type: Int32) {
+        let string = what()
+        
+        //        if (dtime == -1) {
+        //            var rawTime = time_t()
+        //            time(&rawTime)
+        //            var timeinfo = tm()
+        //            localtime_r(&rawTime, &timeinfo)
+        //            dtime = timeinfo.tm_gmtoff
+        //        }
+        //        struct timeval time;
+        //        gettimeofday(&time, NULL);
+        //        int secOfDay = (time.tv_sec + dtime) % (3600 * 24);
+        //        int hour = secOfDay / 3600;
+        //        int minute = secOfDay % 3600 / 60;
+        //        int second = secOfDay % 60;
+        //        int millis = time.tv_usec / 1000;
+        
+        var rawTime = time_t()
+        time(&rawTime)
+        var timeinfo = tm()
+        localtime_r(&rawTime, &timeinfo)
+        
+        var curTime = timeval()
+        gettimeofday(&curTime, nil)
+        let milliseconds = curTime.tv_usec / 1000
+        
+        let content = String(format: "%02d:%02d:%02d.%03d [%d] %@",
+                             arguments: [Int(timeinfo.tm_hour), Int(timeinfo.tm_min), Int(timeinfo.tm_sec), Int(milliseconds), type, string])
+        print(content)
+    }
+    
+    private func hasFreeSpace() -> Bool {
+        let now = Date().timeIntervalSince1970
+        if now > lastCheckFreeSpace+60 {
+            lastCheckFreeSpace = now
+            let freeDiskSpace = freeDiskSpaceInBytes()
+            if freeDiskSpace <= 5*1024*1024 {
+                return false
+            }
+        }
+        return true
+    }
+    
+    private func freeDiskSpaceInBytes() -> Int64 {
+        let fileURL = URL(fileURLWithPath: NSHomeDirectory() as String)
+        guard let values = try? fileURL.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey]), let capacity = values.volumeAvailableCapacityForImportantUsage else {
+            return -1
+        }
+        
+        return capacity
+    }
 }
 
 extension String {
@@ -102,4 +404,25 @@ extension String {
         return data.bytes.bindMemory(to: Int8.self, capacity: data.length)
     }
 }
+
+// MARK: - Private
+private let QueueSpecificKey = DispatchSpecificKey<NSObject>()
+
+private let loganLogDirectory: String = {
+    let path = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first! as NSString
+    return path.appendingPathComponent("LoganLoggerv3") as String
+}()
+
+private let dateFormatter: DateFormatter = {
+    let dateFormatter = DateFormatter()
+    dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+    dateFormatter.dateFormat = "yyyy-MM-dd"
+    return dateFormatter
+}()
+
+private var LOGANUSEASL = false;
+
+private let AES_KEY: String = "0123456789012345"
+private let AES_IV: String = "0123456789012345"
+private let max_file: Int32 = 10 * 1024 * 1024
 

--- a/Example/LoganSwift/example macOS/AppDelegate.swift
+++ b/Example/LoganSwift/example macOS/AppDelegate.swift
@@ -1,0 +1,76 @@
+//
+//  AppDelegate.swift
+//  example macOS
+//
+//  Created by Hanguang on 2019/1/7.
+//  Copyright © 2019 hanguang. All rights reserved.
+//
+
+import Cocoa
+import LoganSwift
+
+let Logan = LoganImpl(context: LoganEncryptionHandler())
+
+@NSApplicationMain
+class AppDelegate: NSObject, NSApplicationDelegate {
+
+    func applicationDidFinishLaunching(_ aNotification: Notification) {
+        Logan.useASL(true)
+    }
+    
+    @IBOutlet weak var window: NSWindow!
+
+    @IBOutlet weak var filesInfo: NSTextField!
+    @IBOutlet weak var ipTextField: NSTextField!
+    
+    private var count: Int = -1
+    
+    @IBAction func logTest(_ sender: NSButton) {
+        for _ in 0..<10 {
+            count += 1
+            eventLog(1, label: "click button \(count)")
+        }
+    }
+    
+    @IBAction func allFilesInfo(_ sender: NSButton) {
+        let files = Logan.allFilesInfo()
+        let log: NSMutableString = NSMutableString()
+        for (k, v) in files {
+            log.appendFormat("文件日期 %@，大小 %d byte\n", k, v)
+        }
+        
+        filesInfo.stringValue = log as String
+    }
+    
+    @IBAction func uploadFile(_ sender: NSButton) {
+        Logan.filePath(Logan.currentDate) { [unowned self] (filePath) in
+            guard !filePath.isEmpty else { return }
+            let path = "http://\(self.ipTextField.stringValue):3000/logupload"
+            let url = URL(string: path)!
+            var request = URLRequest.init(url: url, cachePolicy: .reloadIgnoringCacheData, timeoutInterval: 15)
+            request.httpMethod = "POST"
+            request.addValue("binary/octet-stream", forHTTPHeaderField: "Content-Type")
+            
+            let fileUrl = URL(fileURLWithPath: filePath)
+            let task = URLSession.shared.uploadTask(with: request, fromFile: fileUrl, completionHandler: { (data, urlResponse, error) in
+                switch (data, urlResponse, error) {
+                case (_, _, let error?):
+                    print("upload failed: \(error)")
+                case (let data?, let urlResponse as HTTPURLResponse, _):
+                    print("upload success: data: \(data), response: \(urlResponse)")
+                default:
+                    print("upload failed)")
+                }
+            })
+            
+            task.resume()
+        }
+    }
+    
+    func eventLog(_ type: Int, label: String) {
+        let log = "\(type)" + "    " + label
+        Logan.log(1, log)
+    }
+
+}
+

--- a/Example/LoganSwift/example macOS/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/LoganSwift/example macOS/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "size" : "16x16",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "16x16",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "32x32",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "32x32",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "128x128",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "128x128",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "256x256",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "256x256",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "512x512",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "512x512",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Example/LoganSwift/example macOS/Assets.xcassets/Contents.json
+++ b/Example/LoganSwift/example macOS/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Example/LoganSwift/example macOS/Base.lproj/MainMenu.xib
+++ b/Example/LoganSwift/example macOS/Base.lproj/MainMenu.xib
@@ -1,0 +1,757 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
+            <connections>
+                <outlet property="delegate" destination="Voe-Tx-rLC" id="GzC-gU-4Uq"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application"/>
+        <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="example_macOS" customModuleProvider="target">
+            <connections>
+                <outlet property="filesInfo" destination="7TT-JW-q3b" id="dVy-Aa-wm3"/>
+                <outlet property="ipTextField" destination="7Ix-vc-tMW" id="Rvf-Tc-3mC"/>
+                <outlet property="window" destination="QvC-M9-y7g" id="gIp-Ho-8D9"/>
+            </connections>
+        </customObject>
+        <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
+        <menu title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
+            <items>
+                <menuItem title="example macOS" id="1Xt-HY-uBw">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="example macOS" systemMenu="apple" id="uQy-DD-JDr">
+                        <items>
+                            <menuItem title="About example macOS" id="5kV-Vb-QxS">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="orderFrontStandardAboutPanel:" target="-1" id="Exp-CZ-Vem"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
+                            <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW"/>
+                            <menuItem isSeparatorItem="YES" id="wFC-TO-SCJ"/>
+                            <menuItem title="Services" id="NMo-om-nkz">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Services" systemMenu="services" id="hz9-B4-Xy5"/>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="4je-JR-u6R"/>
+                            <menuItem title="Hide example macOS" keyEquivalent="h" id="Olw-nP-bQN">
+                                <connections>
+                                    <action selector="hide:" target="-1" id="PnN-Uc-m68"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Hide Others" keyEquivalent="h" id="Vdr-fp-XzO">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="hideOtherApplications:" target="-1" id="VT4-aY-XCT"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Show All" id="Kd2-mp-pUS">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="unhideAllApplications:" target="-1" id="Dhg-Le-xox"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="kCx-OE-vgT"/>
+                            <menuItem title="Quit example macOS" keyEquivalent="q" id="4sb-4s-VLi">
+                                <connections>
+                                    <action selector="terminate:" target="-1" id="Te7-pn-YzF"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem title="File" id="dMs-cI-mzQ">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="File" id="bib-Uj-vzu">
+                        <items>
+                            <menuItem title="New" keyEquivalent="n" id="Was-JA-tGl">
+                                <connections>
+                                    <action selector="newDocument:" target="-1" id="4Si-XN-c54"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Open…" keyEquivalent="o" id="IAo-SY-fd9">
+                                <connections>
+                                    <action selector="openDocument:" target="-1" id="bVn-NM-KNZ"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Open Recent" id="tXI-mr-wws">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Open Recent" systemMenu="recentDocuments" id="oas-Oc-fiZ">
+                                    <items>
+                                        <menuItem title="Clear Menu" id="vNY-rz-j42">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="clearRecentDocuments:" target="-1" id="Daa-9d-B3U"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>
+                            <menuItem title="Close" keyEquivalent="w" id="DVo-aG-piG">
+                                <connections>
+                                    <action selector="performClose:" target="-1" id="HmO-Ls-i7Q"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Save…" keyEquivalent="s" id="pxx-59-PXV">
+                                <connections>
+                                    <action selector="saveDocument:" target="-1" id="teZ-XB-qJY"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Save As…" keyEquivalent="S" id="Bw7-FT-i3A">
+                                <connections>
+                                    <action selector="saveDocumentAs:" target="-1" id="mDf-zr-I0C"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Revert to Saved" keyEquivalent="r" id="KaW-ft-85H">
+                                <connections>
+                                    <action selector="revertDocumentToSaved:" target="-1" id="iJ3-Pv-kwq"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="aJh-i4-bef"/>
+                            <menuItem title="Page Setup…" keyEquivalent="P" id="qIS-W8-SiK">
+                                <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                <connections>
+                                    <action selector="runPageLayout:" target="-1" id="Din-rz-gC5"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Print…" keyEquivalent="p" id="aTl-1u-JFS">
+                                <connections>
+                                    <action selector="print:" target="-1" id="qaZ-4w-aoO"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem title="Edit" id="5QF-Oa-p0T">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="Edit" id="W48-6f-4Dl">
+                        <items>
+                            <menuItem title="Undo" keyEquivalent="z" id="dRJ-4n-Yzg">
+                                <connections>
+                                    <action selector="undo:" target="-1" id="M6e-cu-g7V"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Redo" keyEquivalent="Z" id="6dh-zS-Vam">
+                                <connections>
+                                    <action selector="redo:" target="-1" id="oIA-Rs-6OD"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="WRV-NI-Exz"/>
+                            <menuItem title="Cut" keyEquivalent="x" id="uRl-iY-unG">
+                                <connections>
+                                    <action selector="cut:" target="-1" id="YJe-68-I9s"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Copy" keyEquivalent="c" id="x3v-GG-iWU">
+                                <connections>
+                                    <action selector="copy:" target="-1" id="G1f-GL-Joy"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Paste" keyEquivalent="v" id="gVA-U4-sdL">
+                                <connections>
+                                    <action selector="paste:" target="-1" id="UvS-8e-Qdg"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Paste and Match Style" keyEquivalent="V" id="WeT-3V-zwk">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="pasteAsPlainText:" target="-1" id="cEh-KX-wJQ"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Delete" id="pa3-QI-u2k">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="delete:" target="-1" id="0Mk-Ml-PaM"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Select All" keyEquivalent="a" id="Ruw-6m-B2m">
+                                <connections>
+                                    <action selector="selectAll:" target="-1" id="VNm-Mi-diN"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="uyl-h8-XO2"/>
+                            <menuItem title="Find" id="4EN-yA-p0u">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Find" id="1b7-l0-nxx">
+                                    <items>
+                                        <menuItem title="Find…" tag="1" keyEquivalent="f" id="Xz5-n4-O0W">
+                                            <connections>
+                                                <action selector="performFindPanelAction:" target="-1" id="cD7-Qs-BN4"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Find and Replace…" tag="12" keyEquivalent="f" id="YEy-JH-Tfz">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="performFindPanelAction:" target="-1" id="WD3-Gg-5AJ"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Find Next" tag="2" keyEquivalent="g" id="q09-fT-Sye">
+                                            <connections>
+                                                <action selector="performFindPanelAction:" target="-1" id="NDo-RZ-v9R"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Find Previous" tag="3" keyEquivalent="G" id="OwM-mh-QMV">
+                                            <connections>
+                                                <action selector="performFindPanelAction:" target="-1" id="HOh-sY-3ay"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Use Selection for Find" tag="7" keyEquivalent="e" id="buJ-ug-pKt">
+                                            <connections>
+                                                <action selector="performFindPanelAction:" target="-1" id="U76-nv-p5D"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Jump to Selection" keyEquivalent="j" id="S0p-oC-mLd">
+                                            <connections>
+                                                <action selector="centerSelectionInVisibleArea:" target="-1" id="IOG-6D-g5B"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Spelling and Grammar" id="Dv1-io-Yv7">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Spelling" id="3IN-sU-3Bg">
+                                    <items>
+                                        <menuItem title="Show Spelling and Grammar" keyEquivalent=":" id="HFo-cy-zxI">
+                                            <connections>
+                                                <action selector="showGuessPanel:" target="-1" id="vFj-Ks-hy3"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Check Document Now" keyEquivalent=";" id="hz2-CU-CR7">
+                                            <connections>
+                                                <action selector="checkSpelling:" target="-1" id="fz7-VC-reM"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="bNw-od-mp5"/>
+                                        <menuItem title="Check Spelling While Typing" id="rbD-Rh-wIN">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="toggleContinuousSpellChecking:" target="-1" id="7w6-Qz-0kB"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Check Grammar With Spelling" id="mK6-2p-4JG">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="toggleGrammarChecking:" target="-1" id="muD-Qn-j4w"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Correct Spelling Automatically" id="78Y-hA-62v">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="toggleAutomaticSpellingCorrection:" target="-1" id="2lM-Qi-WAP"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Substitutions" id="9ic-FL-obx">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Substitutions" id="FeM-D8-WVr">
+                                    <items>
+                                        <menuItem title="Show Substitutions" id="z6F-FW-3nz">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="orderFrontSubstitutionsPanel:" target="-1" id="oku-mr-iSq"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="gPx-C9-uUO"/>
+                                        <menuItem title="Smart Copy/Paste" id="9yt-4B-nSM">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="toggleSmartInsertDelete:" target="-1" id="3IJ-Se-DZD"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Smart Quotes" id="hQb-2v-fYv">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="toggleAutomaticQuoteSubstitution:" target="-1" id="ptq-xd-QOA"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Smart Dashes" id="rgM-f4-ycn">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="toggleAutomaticDashSubstitution:" target="-1" id="oCt-pO-9gS"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Smart Links" id="cwL-P1-jid">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="toggleAutomaticLinkDetection:" target="-1" id="Gip-E3-Fov"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Data Detectors" id="tRr-pd-1PS">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="toggleAutomaticDataDetection:" target="-1" id="R1I-Nq-Kbl"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Text Replacement" id="HFQ-gK-NFA">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="toggleAutomaticTextReplacement:" target="-1" id="DvP-Fe-Py6"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Transformations" id="2oI-Rn-ZJC">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Transformations" id="c8a-y6-VQd">
+                                    <items>
+                                        <menuItem title="Make Upper Case" id="vmV-6d-7jI">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="uppercaseWord:" target="-1" id="sPh-Tk-edu"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Make Lower Case" id="d9M-CD-aMd">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="lowercaseWord:" target="-1" id="iUZ-b5-hil"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Capitalize" id="UEZ-Bs-lqG">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="capitalizeWord:" target="-1" id="26H-TL-nsh"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Speech" id="xrE-MZ-jX0">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Speech" id="3rS-ZA-NoH">
+                                    <items>
+                                        <menuItem title="Start Speaking" id="Ynk-f8-cLZ">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="startSpeaking:" target="-1" id="654-Ng-kyl"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Stop Speaking" id="Oyz-dy-DGm">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="stopSpeaking:" target="-1" id="dX8-6p-jy9"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem title="Format" id="jxT-CU-nIS">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="Format" id="GEO-Iw-cKr">
+                        <items>
+                            <menuItem title="Font" id="Gi5-1S-RQB">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Font" systemMenu="font" id="aXa-aM-Jaq">
+                                    <items>
+                                        <menuItem title="Show Fonts" keyEquivalent="t" id="Q5e-8K-NDq">
+                                            <connections>
+                                                <action selector="orderFrontFontPanel:" target="YLy-65-1bz" id="WHr-nq-2xA"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Bold" tag="2" keyEquivalent="b" id="GB9-OM-e27">
+                                            <connections>
+                                                <action selector="addFontTrait:" target="YLy-65-1bz" id="hqk-hr-sYV"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Italic" tag="1" keyEquivalent="i" id="Vjx-xi-njq">
+                                            <connections>
+                                                <action selector="addFontTrait:" target="YLy-65-1bz" id="IHV-OB-c03"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Underline" keyEquivalent="u" id="WRG-CD-K1S">
+                                            <connections>
+                                                <action selector="underline:" target="-1" id="FYS-2b-JAY"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="5gT-KC-WSO"/>
+                                        <menuItem title="Bigger" tag="3" keyEquivalent="+" id="Ptp-SP-VEL">
+                                            <connections>
+                                                <action selector="modifyFont:" target="YLy-65-1bz" id="Uc7-di-UnL"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Smaller" tag="4" keyEquivalent="-" id="i1d-Er-qST">
+                                            <connections>
+                                                <action selector="modifyFont:" target="YLy-65-1bz" id="HcX-Lf-eNd"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="kx3-Dk-x3B"/>
+                                        <menuItem title="Kern" id="jBQ-r6-VK2">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Kern" id="tlD-Oa-oAM">
+                                                <items>
+                                                    <menuItem title="Use Default" id="GUa-eO-cwY">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="useStandardKerning:" target="-1" id="6dk-9l-Ckg"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Use None" id="cDB-IK-hbR">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="turnOffKerning:" target="-1" id="U8a-gz-Maa"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Tighten" id="46P-cB-AYj">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="tightenKerning:" target="-1" id="hr7-Nz-8ro"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Loosen" id="ogc-rX-tC1">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="loosenKerning:" target="-1" id="8i4-f9-FKE"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Ligatures" id="o6e-r0-MWq">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Ligatures" id="w0m-vy-SC9">
+                                                <items>
+                                                    <menuItem title="Use Default" id="agt-UL-0e3">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="useStandardLigatures:" target="-1" id="7uR-wd-Dx6"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Use None" id="J7y-lM-qPV">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="turnOffLigatures:" target="-1" id="iX2-gA-Ilz"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Use All" id="xQD-1f-W4t">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="useAllLigatures:" target="-1" id="KcB-kA-TuK"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Baseline" id="OaQ-X3-Vso">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Baseline" id="ijk-EB-dga">
+                                                <items>
+                                                    <menuItem title="Use Default" id="3Om-Ey-2VK">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="unscript:" target="-1" id="0vZ-95-Ywn"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Superscript" id="Rqc-34-cIF">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="superscript:" target="-1" id="3qV-fo-wpU"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Subscript" id="I0S-gh-46l">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="subscript:" target="-1" id="Q6W-4W-IGz"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Raise" id="2h7-ER-AoG">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="raiseBaseline:" target="-1" id="4sk-31-7Q9"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Lower" id="1tx-W0-xDw">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="lowerBaseline:" target="-1" id="OF1-bc-KW4"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="Ndw-q3-faq"/>
+                                        <menuItem title="Show Colors" keyEquivalent="C" id="bgn-CT-cEk">
+                                            <connections>
+                                                <action selector="orderFrontColorPanel:" target="-1" id="mSX-Xz-DV3"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="iMs-zA-UFJ"/>
+                                        <menuItem title="Copy Style" keyEquivalent="c" id="5Vv-lz-BsD">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="copyFont:" target="-1" id="GJO-xA-L4q"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Paste Style" keyEquivalent="v" id="vKC-jM-MkH">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="pasteFont:" target="-1" id="JfD-CL-leO"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Text" id="Fal-I4-PZk">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Text" id="d9c-me-L2H">
+                                    <items>
+                                        <menuItem title="Align Left" keyEquivalent="{" id="ZM1-6Q-yy1">
+                                            <connections>
+                                                <action selector="alignLeft:" target="-1" id="zUv-R1-uAa"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Center" keyEquivalent="|" id="VIY-Ag-zcb">
+                                            <connections>
+                                                <action selector="alignCenter:" target="-1" id="spX-mk-kcS"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Justify" id="J5U-5w-g23">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="alignJustified:" target="-1" id="ljL-7U-jND"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Align Right" keyEquivalent="}" id="wb2-vD-lq4">
+                                            <connections>
+                                                <action selector="alignRight:" target="-1" id="r48-bG-YeY"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="4s2-GY-VfK"/>
+                                        <menuItem title="Writing Direction" id="H1b-Si-o9J">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Writing Direction" id="8mr-sm-Yjd">
+                                                <items>
+                                                    <menuItem title="Paragraph" enabled="NO" id="ZvO-Gk-QUH">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                    </menuItem>
+                                                    <menuItem id="YGs-j5-SAR">
+                                                        <string key="title">	Default</string>
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="makeBaseWritingDirectionNatural:" target="-1" id="qtV-5e-UBP"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem id="Lbh-J2-qVU">
+                                                        <string key="title">	Left to Right</string>
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="makeBaseWritingDirectionLeftToRight:" target="-1" id="S0X-9S-QSf"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem id="jFq-tB-4Kx">
+                                                        <string key="title">	Right to Left</string>
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="makeBaseWritingDirectionRightToLeft:" target="-1" id="5fk-qB-AqJ"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="swp-gr-a21"/>
+                                                    <menuItem title="Selection" enabled="NO" id="cqv-fj-IhA">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                    </menuItem>
+                                                    <menuItem id="Nop-cj-93Q">
+                                                        <string key="title">	Default</string>
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="makeTextWritingDirectionNatural:" target="-1" id="lPI-Se-ZHp"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem id="BgM-ve-c93">
+                                                        <string key="title">	Left to Right</string>
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="makeTextWritingDirectionLeftToRight:" target="-1" id="caW-Bv-w94"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem id="RB4-Sm-HuC">
+                                                        <string key="title">	Right to Left</string>
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="makeTextWritingDirectionRightToLeft:" target="-1" id="EXD-6r-ZUu"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="fKy-g9-1gm"/>
+                                        <menuItem title="Show Ruler" id="vLm-3I-IUL">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="toggleRuler:" target="-1" id="FOx-HJ-KwY"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Copy Ruler" keyEquivalent="c" id="MkV-Pr-PK5">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="copyRuler:" target="-1" id="71i-fW-3W2"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Paste Ruler" keyEquivalent="v" id="LVM-kO-fVI">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="pasteRuler:" target="-1" id="cSh-wd-qM2"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem title="View" id="H8h-7b-M4v">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="View" id="HyV-fh-RgO">
+                        <items>
+                            <menuItem title="Show Toolbar" keyEquivalent="t" id="snW-S8-Cw5">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="toggleToolbarShown:" target="-1" id="BXY-wc-z0C"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Customize Toolbar…" id="1UK-8n-QPP">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="runToolbarCustomizationPalette:" target="-1" id="pQI-g3-MTW"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="hB3-LF-h0Y"/>
+                            <menuItem title="Show Sidebar" keyEquivalent="s" id="kIP-vf-haE">
+                                <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                <connections>
+                                    <action selector="toggleSourceList:" target="-1" id="iwa-gc-5KM"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Enter Full Screen" keyEquivalent="f" id="4J7-dP-txa">
+                                <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                <connections>
+                                    <action selector="toggleFullScreen:" target="-1" id="dU3-MA-1Rq"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem title="Window" id="aUF-d1-5bR">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="Window" systemMenu="window" id="Td7-aD-5lo">
+                        <items>
+                            <menuItem title="Minimize" keyEquivalent="m" id="OY7-WF-poV">
+                                <connections>
+                                    <action selector="performMiniaturize:" target="-1" id="VwT-WD-YPe"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Zoom" id="R4o-n2-Eq4">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="performZoom:" target="-1" id="DIl-cC-cCs"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="eu3-7i-yIM"/>
+                            <menuItem title="Bring All to Front" id="LE2-aR-0XJ">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="arrangeInFront:" target="-1" id="DRN-fu-gQh"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem title="Help" id="wpr-3q-Mcd">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="Help" systemMenu="help" id="F2S-fz-NVQ">
+                        <items>
+                            <menuItem title="example macOS Help" keyEquivalent="?" id="FKE-Sm-Kum">
+                                <connections>
+                                    <action selector="showHelp:" target="-1" id="y7X-2Q-9no"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+            </items>
+        </menu>
+        <window title="example macOS" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="335" y="390" width="480" height="360"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+            <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
+                <rect key="frame" x="0.0" y="0.0" width="480" height="360"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Oc9-bt-5fE">
+                        <rect key="frame" x="80" y="273" width="120" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="push" title="测试日志写入" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Dob-Eu-M8S">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" size="13" name=".PingFangSC-Regular"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="logTest:" target="Voe-Tx-rLC" id="MvF-Aj-4qV"/>
+                        </connections>
+                    </button>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1XC-Zh-53Z">
+                        <rect key="frame" x="80" y="240" width="120" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="push" title="测试日志上报" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="cNI-LR-J25">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" size="13" name=".PingFangSC-Regular"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="uploadFile:" target="Voe-Tx-rLC" id="50E-ZW-c28"/>
+                        </connections>
+                    </button>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bbm-XB-F9e">
+                        <rect key="frame" x="80" y="207" width="120" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="push" title="查看日志信息" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="cJQ-IS-iR1">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" size="13" name=".PingFangSC-Regular"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="allFilesInfo:" target="Voe-Tx-rLC" id="KyV-Ze-JuV"/>
+                        </connections>
+                    </button>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aft-dY-BrV">
+                        <rect key="frame" x="212" y="249" width="57" height="17"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <textFieldCell key="cell" lineBreakMode="clipping" title="server ip" id="uqG-X8-GLp">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7Ix-vc-tMW">
+                        <rect key="frame" x="275" y="246" width="120" height="22"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" title="127.0.0.1" drawsBackground="YES" id="zwT-k1-ZZy">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7TT-JW-q3b">
+                        <rect key="frame" x="84" y="60" width="313" height="141"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <textFieldCell key="cell" lineBreakMode="clipping" title="文件信息" id="5XS-E7-byF">
+                            <font key="font" size="13" name=".PingFangSC-Regular"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                </subviews>
+            </view>
+        </window>
+    </objects>
+</document>

--- a/Example/LoganSwift/example macOS/Info.plist
+++ b/Example/LoganSwift/example macOS/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2019 hanguang. All rights reserved.</string>
+	<key>NSMainNibFile</key>
+	<string>MainMenu</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/Example/LoganSwift/example macOS/example_macOS.entitlements
+++ b/Example/LoganSwift/example macOS/example_macOS.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
+</dict>
+</plist>

--- a/Example/LoganSwift/example/AppDelegate.swift
+++ b/Example/LoganSwift/example/AppDelegate.swift
@@ -1,0 +1,24 @@
+//
+//  AppDelegate.swift
+//  example
+//
+//  Created by Hanguang on 2019/1/7.
+//  Copyright © 2019 hanguang. All rights reserved.
+//
+
+import UIKit
+import LoganSwift
+
+let Logan = LoganImpl(context: LoganEncryptionHandler())
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        Logan.useASL(true)
+        return true
+    }
+}
+

--- a/Example/LoganSwift/example/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/LoganSwift/example/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Example/LoganSwift/example/Assets.xcassets/Contents.json
+++ b/Example/LoganSwift/example/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Example/LoganSwift/example/Base.lproj/LaunchScreen.storyboard
+++ b/Example/LoganSwift/example/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Example/LoganSwift/example/Base.lproj/Main.storyboard
+++ b/Example/LoganSwift/example/Base.lproj/Main.storyboard
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="example" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6B6-V5-VOh">
+                                <rect key="frame" x="44" y="153" width="153" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="查看所有日志文件信息"/>
+                                <connections>
+                                    <action selector="allFilesInfo:" destination="BYZ-38-t0r" eventType="touchUpInside" id="XG6-7Q-Cox"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OjH-WV-7sH">
+                                <rect key="frame" x="44" y="105" width="92" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="测试日志上报"/>
+                                <connections>
+                                    <action selector="uploadFile:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Mf5-sI-kym"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="server ip" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kBX-sN-RAB">
+                                <rect key="frame" x="149" y="110" width="70" height="22"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="127.0.0.1" borderStyle="roundedRect" placeholder="请输入server ip地址" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="kn4-eH-JfK">
+                                <rect key="frame" x="223" y="105" width="97" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <nil key="textColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" keyboardType="numbersAndPunctuation"/>
+                            </textField>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" editable="NO" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="w5E-Bc-Fql">
+                                <rect key="frame" x="44" y="205" width="289" height="171"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bhi-Gs-VUu">
+                                <rect key="frame" x="44" y="58" width="92" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="测试日志写入"/>
+                                <connections>
+                                    <action selector="logTest:" destination="BYZ-38-t0r" eventType="touchUpInside" id="eeg-fV-LpA"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                    <connections>
+                        <outlet property="filesInfo" destination="w5E-Bc-Fql" id="1B9-Jh-S2M"/>
+                        <outlet property="ipTextField" destination="kn4-eH-JfK" id="UOp-5Z-fOG"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Example/LoganSwift/example/Info.plist
+++ b/Example/LoganSwift/example/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Example/LoganSwift/example/LoganExtension.swift
+++ b/Example/LoganSwift/example/LoganExtension.swift
@@ -1,0 +1,21 @@
+//
+//  LoganExtension.swift
+//  example
+//
+//  Created by Hanguang on 2019/1/7.
+//  Copyright © 2019 hanguang. All rights reserved.
+//
+
+import LoganSwift
+
+struct LoganEncryptionHandler: LoganEncryptionContext {}
+
+extension LoganEncryptionContext {
+    var aesKey: String {
+        return "1234567890abcdef"
+    }
+    
+    var aesIv: String {
+        return "1234567890abcdef"
+    }
+}

--- a/Example/LoganSwift/example/ViewController.swift
+++ b/Example/LoganSwift/example/ViewController.swift
@@ -1,0 +1,71 @@
+//
+//  ViewController.swift
+//  example
+//
+//  Created by Hanguang on 2019/1/7.
+//  Copyright © 2019 hanguang. All rights reserved.
+//
+
+import UIKit
+import LoganSwift
+
+class ViewController: UIViewController {
+
+    private var count: Int = -1
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+    @IBOutlet weak var filesInfo: UITextView!
+    @IBOutlet weak var ipTextField: UITextField!
+    
+    
+    @IBAction func logTest(_ sender: UIButton) {
+        for _ in 0..<10 {
+            count += 1
+            eventLog(1, label: "click button \(count)")
+        }
+    }
+    
+    @IBAction func allFilesInfo(_ sender: UIButton) {
+        let files = Logan.allFilesInfo()
+        let log: NSMutableString = NSMutableString()
+        for (k, v) in files {
+            log.appendFormat("文件日期 %@，大小 %d byte\n", k, v)
+        }
+        
+        filesInfo.text = log as String
+    }
+    
+    @IBAction func uploadFile(_ sender: UIButton) {
+        Logan.filePath(Logan.currentDate) { [unowned self] (filePath) in
+            guard !filePath.isEmpty else { return }
+            let path = "http://\(self.ipTextField.text!):3000/logupload"
+            let url = URL(string: path)!
+            var request = URLRequest.init(url: url, cachePolicy: .reloadIgnoringCacheData, timeoutInterval: 15)
+            request.httpMethod = "POST"
+            request.addValue("binary/octet-stream", forHTTPHeaderField: "Content-Type")
+            
+            let fileUrl = URL(fileURLWithPath: filePath)
+            let task = URLSession.shared.uploadTask(with: request, fromFile: fileUrl, completionHandler: { (data, urlResponse, error) in
+                switch (data, urlResponse, error) {
+                case (_, _, let error?):
+                    print("upload failed: \(error)")
+                case (let data?, let urlResponse as HTTPURLResponse, _):
+                    print("upload success: data: \(data), response: \(urlResponse)")
+                default:
+                    print("upload failed)")
+                }
+            })
+            
+            task.resume()
+        }
+    }
+    
+    func eventLog(_ type: Int, label: String) {
+        let log = "\(type)" + "    " + label
+        Logan.log(1, log)
+    }
+}
+

--- a/Logan/Clogan/module.modulemap
+++ b/Logan/Clogan/module.modulemap
@@ -1,0 +1,5 @@
+module Clogan [system][extern_c] {
+    header "clogan_core.h"
+    export *
+}
+

--- a/Logan/iOS/Logan.h
+++ b/Logan/iOS/Logan.h
@@ -28,9 +28,9 @@ extern void loganUseASL(BOOL b);
 /**
  返回文件路径
  
- @param filePatch filePath，nil时表示文件不存在
+ @param filePath nil时表示文件不存在
  */
-typedef void (^LoganFilePatchBlock)(NSString *_Nullable filePatch);
+typedef void (^LoganFilePathBlock)(NSString *_Nullable filePath);
 
 /**
  logan初始化
@@ -87,9 +87,9 @@ extern NSDictionary *_Nullable loganAllFilesInfo(void);
  根据日期获取上传日志的文件路径，异步方式！
  
  @param date 日志日期 格式："2018-11-21"
- @param filePatchBlock 回调返回文件路径，在主线程中回调
+ @param filePathBlock 回调返回文件路径，在主线程中回调
  */
-extern void loganUploadFilePath(NSString *_Nonnull date, LoganFilePatchBlock _Nonnull filePatchBlock);
+extern void loganUploadFilePath(NSString *_Nonnull date, LoganFilePathBlock _Nonnull filePathBlock);
 
 /**
  返回今天日期

--- a/Logan/iOS/Logan.m
+++ b/Logan/iOS/Logan.m
@@ -361,10 +361,10 @@ NSString *_Nonnull loganTodaysDate(void) {
         if ([file pathExtension].length > 0) {
             continue;
         }
-        NSString *detaString = [file substringToIndex:dateFormatString.length];
-        unsigned long long gzFileSize = [Logan fileSizeAtPath:[self logFilePath:detaString]];
+        NSString *dateString = [file substringToIndex:dateFormatString.length];
+        unsigned long long gzFileSize = [Logan fileSizeAtPath:[self logFilePath:dateString]];
         NSString *size = [NSString stringWithFormat:@"%llu", gzFileSize];
-        [infoDic setObject:size forKey:detaString];
+        [infoDic setObject:size forKey:dateString];
     }
     return infoDic;
 }

--- a/Logan/iOS/Logan.m
+++ b/Logan/iOS/Logan.m
@@ -373,6 +373,7 @@ NSString *_Nonnull loganTodaysDate(void) {
 + (NSString *)uploadFilePath:(NSString *)date {
     return [[self loganLogDirectory] stringByAppendingPathComponent:[NSString stringWithFormat:@"%@.temp", date]];
 }
+
 + (NSString *)logFilePath:(NSString *)date {
     return [[Logan loganLogDirectory] stringByAppendingPathComponent:[Logan logFileName:date]];
 }

--- a/Logan/iOS/Logan.m
+++ b/Logan/iOS/Logan.m
@@ -55,7 +55,7 @@ uint64_t __max_file;
 + (NSDictionary *)allFilesInfo;
 + (NSString *)currentDate;
 - (void)flash;
-- (void)filePatchForDate:(NSString *)date block:(LoganFilePatchBlock)filePatchBlock;
+- (void)filePathForDate:(NSString *)date block:(LoganFilePathBlock)filePathBlock;
 @end
 
 void loganInit(NSData *_Nonnull aes_key16, NSData *_Nonnull aes_iv16, uint64_t max_file) {
@@ -84,8 +84,8 @@ NSDictionary *_Nullable loganAllFilesInfo(void) {
     return [Logan allFilesInfo];
 }
 
-void loganUploadFilePath(NSString *_Nonnull date, LoganFilePatchBlock _Nonnull filePatchBlock) {
-    [[Logan logan] filePatchForDate:date block:filePatchBlock];
+void loganUploadFilePath(NSString *_Nonnull date, LoganFilePathBlock _Nonnull filePathBlock) {
+    [[Logan logan] filePathForDate:date block:filePathBlock];
 }
 
 void loganFlash(void) {
@@ -297,7 +297,7 @@ NSString *_Nonnull loganTodaysDate(void) {
     [self flash];
 }
 
-- (void)filePatchForDate:(NSString *)date block:(LoganFilePatchBlock)filePatchBlock {
+- (void)filePathForDate:(NSString *)date block:(LoganFilePathBlock)filePathBlock {
     NSString *uploadFilePath = nil;
     NSString *filePath = nil;
     if (date.length) {
@@ -313,17 +313,17 @@ NSString *_Nonnull loganTodaysDate(void) {
     if (uploadFilePath.length) {
         if ([date isEqualToString:[Logan currentDate]]) {
             dispatch_async(self.loganQueue, ^{
-                [self todayFilePatch:filePatchBlock];
+                [self todayFilePatch:filePathBlock];
             });
             return;
         }
     }
     dispatch_async(dispatch_get_main_queue(), ^{
-        filePatchBlock(uploadFilePath);
+        filePathBlock(uploadFilePath);
     });
 }
 
-- (void)todayFilePatch:(LoganFilePatchBlock)filePatchBlock {
+- (void)todayFilePatch:(LoganFilePathBlock)filePathBlock {
     [self flashInQueue];
     NSString *uploadFilePath = [Logan uploadFilePath:[Logan currentDate]];
     NSString *filePath = [Logan logFilePath:[Logan currentDate]];
@@ -334,7 +334,7 @@ NSString *_Nonnull loganTodaysDate(void) {
     }
     
     dispatch_async(dispatch_get_main_queue(), ^{
-        filePatchBlock(uploadFilePath);
+        filePathBlock(uploadFilePath);
     });
 }
 


### PR DESCRIPTION
原同事和我提到了这个库，看了一下确实不错，而且全端都支持，唯独有点遗憾是不支持原生Swift，
而我又是Swift原生党。
正巧Swift支持和C库直接交互，就想到是否可以实现一个原生Swift的扩展，顺便为大佬们做点贡献。

主要设计思想和命名基本沿用Objective-C的不变，但是由于swift的一些特性需求做了一些命名上的更改的不同实现。

这份PR主要是包含了Swift的实现和example，请过目一下 看看有什么需要调整的。
目前没有增加pod支持，等你们review完了我改好了之后 会增加cocoapods文件。