### PR TITLE
fix: Objective-C 的封装在初始化时使用了错误的变量

### DIFF
--- a/Logan/iOS/Logan.m
+++ b/Logan/iOS/Logan.m
@@ -59,7 +59,7 @@ uint64_t __max_file;
 @end
 
 void loganInit(NSData *_Nonnull aes_key16, NSData *_Nonnull aes_iv16, uint64_t max_file) {
-    __AES_KEY = aes_iv16;
+    __AES_KEY = aes_key16;
     __AES_IV = aes_iv16;
     __max_file = max_file;
 }


### PR DESCRIPTION
Example 里的 `iv` 和 `key` 使用了一样的值，绕过了这个 Bug，可能改成不一样的会容易发现类似的问题。如果有需要的话，我可以在这个 PR 里顺便一起改掉。