### PR TITLE
fix(docs,example): Corrected typo

### DIFF
--- a/Flutter/README.md
+++ b/Flutter/README.md
@@ -45,14 +45,14 @@ you can use this method to upload your logs directly into your server. we also p
     try {
       final today = DateTime.now();
       final date = "${today.year.toString()}-${today.month.toString().padLeft(2, '0')}-${today.day.toString().padLeft(2, '0')}";
-      final bool bakc = await FlutterLogan.upload(
+      final bool back = await FlutterLogan.upload(
           'http://127.0.0.1:3000/logupload',
           date,
           'FlutterTestAppId',
           'FlutterTestUnionId',
           'FlutterTestDeviceId'
           );
-      if (bakc) {
+      if (back) {
         result = 'Upload to server succeed';
       }
     } on PlatformException {

--- a/Flutter/example/lib/main.dart
+++ b/Flutter/example/lib/main.dart
@@ -101,14 +101,14 @@ class _MyAppState extends State<MyApp> {
     try {
       final today = DateTime.now();
       final date = "${today.year.toString()}-${today.month.toString().padLeft(2, '0')}-${today.day.toString().padLeft(2, '0')}";
-      final bool bakc = await FlutterLogan.upload(
+      final bool back = await FlutterLogan.upload(
           'http://127.0.0.1:3000/logupload',
           date,
           'FlutterTestAppId',
           'FlutterTestUnionId',
           'FlutterTestDeviceId'
           );
-      if (bakc) {
+      if (back) {
         result = 'Upload to server succeed';
       }
     } on PlatformException {


### PR DESCRIPTION
Corrected typo, bakc => back in example/lib/main.dart and English README.md
"bakc" was used consistently in main.dart, so did not cause any errors, but may be confusing to the reader.
Correction increases clarity and maintains consistent usage.