### PR TITLE
Optimized:reduce times of "is_file_exist" method.

### DIFF
--- a/Logan/Clogan/clogan_core.c
+++ b/Logan/Clogan/clogan_core.c
@@ -687,24 +687,10 @@ clogan_write(int flag, char *log, long long local_time, char *thread_name, long 
         return back;
     }
 
-    if (is_file_exist_clogan(logan_model->file_path)) {
-        if (logan_model->file_len > max_file_len) {
-            printf_clogan("clogan_write > beyond max file , cant write log\n");
-            back = CLOAGN_WRITE_FAIL_MAXFILE;
-            return back;
-        }
-    } else {
-        if (logan_model->file_stream_type == LOGAN_FILE_OPEN) {
-            fclose(logan_model->file);
-            logan_model->file_stream_type = LOGAN_FILE_CLOSE;
-        }
-        if (NULL != _dir_path) {
-            if (!is_file_exist_clogan(_dir_path)) {
-                makedir_clogan(_dir_path);
-            }
-            init_file_clogan(logan_model);
-            printf_clogan("clogan_write > create log file , restore open file stream \n");
-        }
+    if(logan_model->file_len > max_file_len) {
+        printf_clogan("clogan_write > beyond max file , cant write log\n");
+        back = CLOAGN_WRITE_FAIL_MAXFILE;
+        return back;
     }
 
     //判断MMAP文件是否存在,如果被删除,用内存缓存


### PR DESCRIPTION
原逻辑：
每次判断文件是否存在
若存在，则判断文件是否超过最大size；若超过则返回；
若不存在，如果文件已打开，则关闭文件流。判断文件根目录是否有值且存在，若不存在创建根目录，且重新初始化文件
优化逻辑：
这里只判断文件是否超过最大size，若超过则返回。
原因：
初始化时(clogan_init())已创建打开文件，而且在每次写log文件(write_dest_clogan())的时候都会重复上述判断，每次写日志都判断文件是否存在意义不太大。
access()方法有一定性能开销。