### PR TITLE
fix : Construct_ The reference of # include "stdlib. h" in the data. …

### DIFF
--- a/Logan/Clogan/construct_data.c
+++ b/Logan/Clogan/construct_data.c
@@ -23,7 +23,7 @@
 #include <string.h>
 #include "construct_data.h"
 #include "cJSON.h"
-#include "stdlib.h"
+#include <stdlib.h>
 #include "json_util.h"
 #include "console_util.h"
 


### PR DESCRIPTION
…c file is replaced with # include<stdlib. h>to resolve the reference conflict with other third-party files.

Issues#462