### PR TITLE
后端日志解析优化，解决日志丢失问题

### DIFF
--- a/Logan/Clogan/CMakeLists.txt
+++ b/Logan/Clogan/CMakeLists.txt
@@ -21,3 +21,6 @@ set(SOURCE_FILES
 add_library (clogan ${SOURCE_FILES})
 target_link_libraries(clogan mbedcrypto)
 target_link_libraries(clogan z)
+
+add_executable(clogan_runner main.c)
+target_link_libraries(clogan_runner clogan)

--- a/Logan/Clogan/CMakeLists.txt
+++ b/Logan/Clogan/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 
+project(clogan)
+
 set(MBEDTSL_INCLUDE ../mbedtls/include)
 set(MBEDTSL_LIBRARY ../mbedtls/library)
 
@@ -18,3 +20,4 @@ set(SOURCE_FILES
 
 add_library (clogan ${SOURCE_FILES})
 target_link_libraries(clogan mbedcrypto)
+target_link_libraries(clogan z)

--- a/Logan/Clogan/main.c
+++ b/Logan/Clogan/main.c
@@ -1,0 +1,37 @@
+#include "base_util.h"
+#include "clogan_core.h"
+#include <stdio.h>
+#include <time.h>
+
+int main(int argc, const char **argv) {
+  char key[16] = "0123456789012345";
+  char iv[16] = "0123456789012345";
+  int code;
+
+  clogan_debug(0);
+  code = clogan_init("log", "log", 10 * 1024 * 1024, key, iv);
+  printf("[init]: %d\n", code);
+
+  code = clogan_open("logan.bin");
+  printf("[open]: %d\n", code);
+
+  long long ts = get_system_current_clogan();
+  time_t now = time(NULL);
+  char *now_str = ctime(&now);
+  printf("[now]: %s\n", now_str);
+
+  clogan_flush();
+  clogan_write(10, now_str, ts, "main", 1, 1);
+  clogan_write(10, "[log 1]", ts++, "main", 1, 1);
+  clogan_write(10, "[log 2]", ts++, "main", 1, 1);
+  clogan_write(10, "[log 3]", ts++, "main", 1, 1);
+  clogan_write(10, "[log 4]", ts++, "main", 1, 1);
+  clogan_write(10, "[log 5]", ts++, "main", 1, 1);
+  clogan_write(10, "how", ts++, "main", 1, 1);
+  clogan_write(10, "are", ts++, "main", 1, 1);
+  clogan_write(10, "you", ts++, "main", 1, 1);
+  clogan_write(10, "fine", ts++, "main", 1, 1);
+  //  clogan_flush();
+
+  printf("[exit]\n");
+}

--- a/Logan/Server/src/main/java/com/meituan/logan/web/parser/LegacyLoganProtocol.java
+++ b/Logan/Server/src/main/java/com/meituan/logan/web/parser/LegacyLoganProtocol.java
@@ -1,0 +1,136 @@
+package com.meituan.logan.web.parser;
+
+import com.meituan.logan.web.enums.ResultEnum;
+import com.meituan.logan.web.model.Tuple;
+import org.apache.commons.io.IOUtils;
+import org.apache.log4j.Logger;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.springframework.core.io.support.PropertiesLoaderUtils;
+
+import javax.annotation.PreDestroy;
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.security.Security;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * 老版本解析器
+ */
+public class LegacyLoganProtocol {
+
+    private static final Logger LOGGER = Logger.getLogger(LoganProtocol.class);
+
+    private static final char ENCRYPT_CONTENT_START = '\1';
+
+    private static final String AES_ALGORITHM_TYPE = "AES/CBC/NoPadding";
+
+    private static AtomicBoolean initialized = new AtomicBoolean(false);
+
+    static {
+        initialize();
+    }
+
+    private ByteBuffer wrap;
+    private FileOutputStream fileOutputStream;
+
+    public LegacyLoganProtocol(InputStream stream, File file) {
+        try {
+            wrap = ByteBuffer.wrap(IOUtils.toByteArray(stream));
+            fileOutputStream = new FileOutputStream(file);
+        } catch (IOException e) {
+            LOGGER.error(e);
+        }
+    }
+
+    public ResultEnum process() {
+        while (wrap.hasRemaining()) {
+            while (wrap.hasRemaining() && wrap.get() == ENCRYPT_CONTENT_START) {
+                byte[] encrypt = new byte[wrap.getInt()];
+                if (!tryGetEncryptContent(encrypt) || !decryptAndAppendFile(encrypt)) {
+                    return ResultEnum.ERROR_DECRYPT;
+                }
+            }
+        }
+        return ResultEnum.SUCCESS;
+    }
+
+    private boolean tryGetEncryptContent(byte[] encrypt) {
+        try {
+            wrap.get(encrypt);
+        } catch (java.nio.BufferUnderflowException e) {
+            LOGGER.error(e);
+            return false;
+        }
+        return true;
+    }
+
+    private boolean decryptAndAppendFile(byte[] encrypt) {
+        boolean result = false;
+        try {
+            Cipher aesEncryptCipher = Cipher.getInstance(AES_ALGORITHM_TYPE);
+            Tuple<String, String> secureParam = getSecureParam();
+            if (secureParam == null) {
+                return false;
+            }
+            SecretKeySpec secretKeySpec = new SecretKeySpec(secureParam.getFirst().getBytes(), "AES");
+            aesEncryptCipher.init(Cipher.DECRYPT_MODE, secretKeySpec, new IvParameterSpec(secureParam.getSecond().getBytes()));
+            byte[] compressed = aesEncryptCipher.doFinal(encrypt);
+            byte[] plainText = decompress(compressed);
+            result = true;
+            fileOutputStream.write(plainText);
+            fileOutputStream.flush();
+        } catch (Exception e) {
+            LOGGER.error(e);
+        }
+        return result;
+    }
+
+    private static byte[] decompress(byte[] contentBytes) {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            IOUtils.copy(new GZIPInputStream(new ByteArrayInputStream(contentBytes)), out);
+            return out.toByteArray();
+        } catch (IOException e) {
+            LOGGER.error(e);
+        }
+        return new byte[0];
+    }
+
+    @PreDestroy
+    public void closeFileSteam() {
+        try {
+            fileOutputStream.close();
+        } catch (IOException e) {
+            LOGGER.error(e);
+        }
+    }
+
+    /**
+     * BouncyCastle作为安全提供，防止我们加密解密时候因为jdk内置的不支持改模式运行报错。
+     **/
+    private static void initialize() {
+        if (initialized.get()) {
+            return;
+        }
+        Security.addProvider(new BouncyCastleProvider());
+        initialized.set(true);
+    }
+
+
+    private static Tuple<String, String> getSecureParam() {
+        try {
+            Properties properties = PropertiesLoaderUtils.loadAllProperties("secure.properties");
+            Tuple<String, String> tuple = new Tuple<>();
+            tuple.setFirst(properties.getProperty("AES_KEY"));
+            tuple.setSecond(properties.getProperty("IV"));
+            return tuple;
+        } catch (IOException e) {
+            LOGGER.error(e);
+        }
+        return null;
+    }
+}

--- a/Logan/Server/src/main/java/com/meituan/logan/web/parser/LoganProtocol.java
+++ b/Logan/Server/src/main/java/com/meituan/logan/web/parser/LoganProtocol.java
@@ -1,7 +1,9 @@
 package com.meituan.logan.web.parser;
 
 import com.meituan.logan.web.enums.ResultEnum;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.LineIterator;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.log4j.Logger;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -161,5 +163,30 @@ public class LoganProtocol {
     private boolean checkSecureParams() {
         return secretKey != null && secretKey.length == 16 &&
                 iv != null && iv.length == 16;
+    }
+
+    private static int countLines(File file) throws IOException {
+        int count = 0;
+        try (LineIterator iterator = FileUtils.lineIterator(file)) {
+            while (iterator.hasNext()) {
+                count++;
+                iterator.next();
+            }
+        }
+        return count;
+    }
+
+    public static void main(String[] args) throws IOException {
+        if (args.length < 2) {
+            System.exit(-1);
+        }
+        File input = new File(args[0]); // 原始文件路径
+        File output = new File(args[1]); // 输出文件路径
+        try (FileInputStream inputStream = new FileInputStream(input)) {
+            LoganProtocol protocol = new LoganProtocol(inputStream, output);
+            ResultEnum result = protocol.process();
+            System.out.println("result: " + result);
+        }
+        System.out.println("output lines: " + countLines(output));
     }
 }

--- a/Logan/Server/src/main/java/com/meituan/logan/web/parser/LoganProtocol.java
+++ b/Logan/Server/src/main/java/com/meituan/logan/web/parser/LoganProtocol.java
@@ -188,5 +188,13 @@ public class LoganProtocol {
             System.out.println("result: " + result);
         }
         System.out.println("output lines: " + countLines(output));
+
+        output = new File(output.getAbsolutePath() + ".legacy");
+        try (FileInputStream inputStream = new FileInputStream(input)) {
+            LegacyLoganProtocol protocol = new LegacyLoganProtocol(inputStream, output);
+            ResultEnum result = protocol.process();
+            System.out.println("legacy result: " + result);
+        }
+        System.out.println("legacy output lines: " + countLines(output));
     }
 }

--- a/Logan/Server/src/main/java/com/meituan/logan/web/parser/LoganProtocol.java
+++ b/Logan/Server/src/main/java/com/meituan/logan/web/parser/LoganProtocol.java
@@ -49,7 +49,7 @@ public class LoganProtocol {
 
     public ResultEnum process() {
         while (wrap.hasRemaining()) {
-            while (wrap.get() == ENCRYPT_CONTENT_START) {
+            while (wrap.hasRemaining() && wrap.get() == ENCRYPT_CONTENT_START) {
                 byte[] encrypt = new byte[wrap.getInt()];
                 if (!tryGetEncryptContent(encrypt) || !decryptAndAppendFile(encrypt)) {
                     return ResultEnum.ERROR_DECRYPT;


### PR DESCRIPTION
- **【解压优化】** GZIP 解压缩失败时避免丢弃已经解压的数据，实际测试大部分情况下可以解决 #447 提到的没有 flush 导致末尾日志丢失问题
- **【解密优化】** 解密时会先尝试用 PKCS5Padding 模式解密末尾 16 字节
    - 如果成功说明尾部包含合法的 PKCS5Padding，使用 PKCS5Padding 模式解密
    - 如果捕获到 `BadPaddingException` 说明末尾没有添加 Padding（没有 flush），使用 NoPadding 模式解密
- **【其他】** 解析时添加 `hasRemaining()` 检查，解决 #402 
