### PR TITLE
refactor(clogan): 使用 mlock 防止内存被释放，默认不开启

### DIFF
--- a/Logan/Clogan/mmap_util.c
+++ b/Logan/Clogan/mmap_util.c
@@ -82,6 +82,9 @@ int open_mmap_file_clogan(char *_filepath, unsigned char **buffer, unsigned char
 
             if (isFileOk) {
                 p_map = (unsigned char *) mmap(0, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+#ifdef CLOGAN_MLOCK
+                mlock(p_map, size);
+#endif
             }
             if (p_map != MAP_FAILED && NULL != p_map && isFileOk) {
                 back = LOGAN_MMAP_MMAP;


### PR DESCRIPTION
#488 或与 iOS 后台内存释放机制有关，尝试使用 mlock 避免。默认不开启，需使用宏 `-DCLOGAN_MLOCK` 开启。