### PR TITLE
解决在支持16KB的模拟机上闪退问题

### DIFF
--- a/Example/Logan-Android/app/build.gradle
+++ b/Example/Logan-Android/app/build.gradle
@@ -16,6 +16,7 @@ android {
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.debug
         }
     }
 }

--- a/Example/Logan-Android/app/build.gradle
+++ b/Example/Logan-Android/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
+    namespace "test.logan.dianping.com.logan"
+
     compileSdk 34
 
     defaultConfig {
-        applicationId "test.logan.dianping.com.logan"
-        namespace "test.logan.dianping.com.logan"
         minSdkVersion 21
         targetSdkVersion 34
         versionCode 1

--- a/Example/Logan-Android/app/build.gradle
+++ b/Example/Logan-Android/app/build.gradle
@@ -1,15 +1,16 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "25.0.2"
+    compileSdk 34
+
     defaultConfig {
         applicationId "test.logan.dianping.com.logan"
-        minSdkVersion 14
-        targetSdkVersion 23
+        namespace "test.logan.dianping.com.logan"
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
@@ -20,12 +21,12 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
-        exclude group: 'com.android.support', module: 'support-annotations'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    androidTestImplementation('androidx.test.espresso:espresso-core:3.5.1', {
+        exclude group: 'androidx.test', module: 'test-annotations'
     })
-    testCompile 'junit:junit:4.12'
-    compile project(':logan')
+    testImplementation 'junit:junit:4.12'
+    implementation project(':logan')
 //    compile 'com.dianping.android.sdk:logan:1.1.0'
 //    releaseCompile project(path: ':logan', configuration: 'release')
 //    debugCompile project(path: ':logan', configuration: 'debug')

--- a/Example/Logan-Android/app/src/main/AndroidManifest.xml
+++ b/Example/Logan-Android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="test.logan.dianping.com.logan">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
@@ -13,7 +12,9 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true">
-        <activity android:name=".MainActivity">
+        <activity 
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 

--- a/Example/Logan-Android/build.gradle
+++ b/Example/Logan-Android/build.gradle
@@ -10,8 +10,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.2.2'
-        //classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
-        //classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Example/Logan-Android/build.gradle
+++ b/Example/Logan-Android/build.gradle
@@ -9,7 +9,8 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.2'
+        //https://mvnrepository.com/artifact/com.android.tools.build/gradle?p=12
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
 

--- a/Example/Logan-Android/build.gradle
+++ b/Example/Logan-Android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:8.2.2'
         //classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         //classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
 

--- a/Example/Logan-Android/build.gradle
+++ b/Example/Logan-Android/build.gradle
@@ -10,8 +10,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+        //classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
+        //classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Example/Logan-Android/gradle.properties
+++ b/Example/Logan-Android/gradle.properties
@@ -11,6 +11,8 @@
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
 
+android.useAndroidX=true
+
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/Example/Logan-Android/gradle/wrapper/gradle-wrapper.properties
+++ b/Example/Logan-Android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip

--- a/Example/Logan-Android/gradle/wrapper/gradle-wrapper.properties
+++ b/Example/Logan-Android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+#https://services.gradle.org/distributions/
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip

--- a/Example/Logan-Android/logan/.gitignore
+++ b/Example/Logan-Android/logan/.gitignore
@@ -1,1 +1,2 @@
 /build
+/.cxx/

--- a/Example/Logan-Android/logan/CMakeLists.txt
+++ b/Example/Logan-Android/logan/CMakeLists.txt
@@ -26,6 +26,5 @@ find_library( # Sets the name of the path variable.
 add_library(logan SHARED src/main/jni/clogan_protocol.c)
 target_link_libraries(logan ${log-lib} z clogan)
 
-# https://developer.android.com/guide/practices/page-sizes?hl=zh-cn#compile-r22-lower
+#https://developer.android.com/guide/practices/page-sizes?hl=zh-cn#compile-r26-lower
 target_link_options(logan PRIVATE "-Wl,-z,max-page-size=16384")
-target_link_options(logan PRIVATE "-Wl,-z,common-page-size=16384")

--- a/Example/Logan-Android/logan/CMakeLists.txt
+++ b/Example/Logan-Android/logan/CMakeLists.txt
@@ -25,7 +25,3 @@ find_library( # Sets the name of the path variable.
 
 add_library(logan SHARED src/main/jni/clogan_protocol.c)
 target_link_libraries(logan ${log-lib} z clogan)
-
-# https://developer.android.com/guide/practices/page-sizes?hl=zh-cn#compile-r22-lower
-target_link_options(logan PRIVATE "-Wl,-z,max-page-size=16384")
-target_link_options(logan PRIVATE "-Wl,-z,common-page-size=16384")

--- a/Example/Logan-Android/logan/CMakeLists.txt
+++ b/Example/Logan-Android/logan/CMakeLists.txt
@@ -25,3 +25,7 @@ find_library( # Sets the name of the path variable.
 
 add_library(logan SHARED src/main/jni/clogan_protocol.c)
 target_link_libraries(logan ${log-lib} z clogan)
+
+# https://developer.android.com/guide/practices/page-sizes?hl=zh-cn#compile-r22-lower
+target_link_options(logan PRIVATE "-Wl,-z,max-page-size=16384")
+target_link_options(logan PRIVATE "-Wl,-z,common-page-size=16384")

--- a/Example/Logan-Android/logan/build.gradle
+++ b/Example/Logan-Android/logan/build.gradle
@@ -3,6 +3,7 @@ apply from: rootProject.file("bintrayUpload.gradle")
 
 android {
 //    publishNonDefault true
+    namespace "com.dianping.logan"
 
     compileSdk 34
 
@@ -10,7 +11,6 @@ android {
     ndkVersion "16.1.4479499"
 
     defaultConfig {
-        namespace "com.dianping.logan"
         minSdkVersion 21
         targetSdkVersion 34
         versionCode 1

--- a/Example/Logan-Android/logan/build.gradle
+++ b/Example/Logan-Android/logan/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdk 34
 
     //https://github.com/Meituan-Dianping/Logan/tree/master/Example/Logan-Android#prerequisites
-    ndkVersion "27.3.13750724"
+    ndkVersion "16.1.4479499"
 
     defaultConfig {
         minSdkVersion 21
@@ -19,9 +19,9 @@ android {
 
         externalNativeBuild {
             cmake {
-                arguments '-DBUILD_TESTING=OFF'
+                arguments '-DBUILD_TESTING=OFF', '-DANDROID_TOOLCHAIN=gcc'
                 cFlags "-std=c11"
-                abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+                abiFilters 'armeabi', 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
             }
         }
     }

--- a/Example/Logan-Android/logan/build.gradle
+++ b/Example/Logan-Android/logan/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'com.android.library'
-//apply from: rootProject.file("bintrayUpload.gradle")
+apply from: rootProject.file("bintrayUpload.gradle")
 
 android {
 //    publishNonDefault true

--- a/Example/Logan-Android/logan/build.gradle
+++ b/Example/Logan-Android/logan/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'com.android.library'
-apply from: rootProject.file("bintrayUpload.gradle")
+//apply from: rootProject.file("bintrayUpload.gradle")
 
 android {
 //    publishNonDefault true

--- a/Example/Logan-Android/logan/build.gradle
+++ b/Example/Logan-Android/logan/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdk 34
 
     //https://github.com/Meituan-Dianping/Logan/tree/master/Example/Logan-Android#prerequisites
-    ndkVersion "16.1.4479499"
+    ndkVersion "23.2.8568313"
 
     defaultConfig {
         minSdkVersion 21
@@ -19,9 +19,9 @@ android {
 
         externalNativeBuild {
             cmake {
-                arguments '-DBUILD_TESTING=OFF', '-DANDROID_TOOLCHAIN=gcc'
+                arguments '-DBUILD_TESTING=OFF'
                 cFlags "-std=c11"
-                abiFilters 'armeabi', 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+                abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
             }
         }
     }

--- a/Example/Logan-Android/logan/build.gradle
+++ b/Example/Logan-Android/logan/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdk 34
 
     //https://github.com/Meituan-Dianping/Logan/tree/master/Example/Logan-Android#prerequisites
-    ndkVersion "29.0.13113456"
+    ndkVersion "27.3.13750724"
 
     defaultConfig {
         minSdkVersion 21

--- a/Example/Logan-Android/logan/build.gradle
+++ b/Example/Logan-Android/logan/build.gradle
@@ -4,11 +4,10 @@ apply from: rootProject.file("bintrayUpload.gradle")
 android {
 //    publishNonDefault true
     namespace "com.dianping.logan"
-
     compileSdk 34
 
     //https://github.com/Meituan-Dianping/Logan/tree/master/Example/Logan-Android#prerequisites
-    ndkVersion "16.1.4479499"
+    ndkVersion "29.0.13113456"
 
     defaultConfig {
         minSdkVersion 21
@@ -20,9 +19,9 @@ android {
 
         externalNativeBuild {
             cmake {
-                arguments '-DBUILD_TESTING=OFF', '-DANDROID_TOOLCHAIN=gcc'
+                arguments '-DBUILD_TESTING=OFF'
                 cFlags "-std=c11"
-                abiFilters 'armeabi', 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+                abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
             }
         }
     }

--- a/Example/Logan-Android/logan/build.gradle
+++ b/Example/Logan-Android/logan/build.gradle
@@ -4,16 +4,19 @@ apply plugin: 'com.android.library'
 android {
 //    publishNonDefault true
 
-    compileSdkVersion 23
-    buildToolsVersion "25.0.2"
+    compileSdk 34
+
+    //https://github.com/Meituan-Dianping/Logan/tree/master/Example/Logan-Android#prerequisites
+    ndkVersion "16.1.4479499"
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 23
+        namespace "com.dianping.logan"
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         externalNativeBuild {
             cmake {
@@ -41,9 +44,9 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
-        exclude group: 'com.android.support', module: 'support-annotations'
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    androidTestImplementation('androidx.test.espresso:espresso-core:3.5.1', {
+        exclude group: 'androidx.test', module: 'test-annotations'
     })
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 }


### PR DESCRIPTION
#### 构建环境
* NDK：~~16.1.4479499~~  29.0.13113456
* JDK: 17
* Android Studio：Android Studio Meerkat Feature Drop | 2024.3.2

#### 如何本地运行
* 注释掉上传远程库相关逻辑，参考：https://github.com/scsfwgy/Logan/commit/5e2e7909d9db804140a81592940a961614245a55
* 下载ndk版本16.1.4479499：tools->SDK Manager->SDK tools->NDK->16.1.4479499
* 构建包：`./gradlew clean build`
* 打对外aar：` ./gradlew clean :logan:assembleRelease`

#### 修改范围
* 适配新版本AndroidStudio,不然运行不起来
	* gradle-8.2=>gradle-8.2
	* apg：2.3.3=>8.2.2、
	* ~~强制固定ndk版本：ndkVersion "16.1.4479499"，这个是logan官方要求的最高版本~~，用 ndkVersion “29.0.13113456”进行编译
	* 修复构建报错信息，主要是各种版本兼容问题，都是常规修改
	* 修正过时方法

*  修复在支持16KB的模拟器上闪退问题。参考：https://developer.android.com/guide/practices/page-sizes?hl=zh-cn#compile-r22-lower

#### 追踪问题
* https://github.com/Meituan-Dianping/Logan/issues/538