### PR TITLE
Prevent arithmetic overflow on bounds check

### DIFF
--- a/Logan/mbedtls/library/ssl_cli.c
+++ b/Logan/mbedtls/library/ssl_cli.c
@@ -2473,7 +2473,7 @@ static int ssl_parse_server_key_exchange( mbedtls_ssl_context *ssl )
         sig_len = ( p[0] << 8 ) | p[1];
         p += 2;
 
-        if( end != p + sig_len )
+        if( p != end - sig_len )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad server key exchange message" ) );
             mbedtls_ssl_send_alert_message( ssl, MBEDTLS_SSL_ALERT_LEVEL_FATAL,


### PR DESCRIPTION
This PR fixes a security vulnerability in `ssl_parse_server_key_exchange ` that was cloned from Mbed-TLS/mbedtls but did not receive the security patch.

**Vulnerability Details:**

* **Affected Function**: `ssl_parse_server_key_exchange ` in `Logan/mbedtls/library/ssl_cli.c`
* **Original Fix**: https://github.com/Mbed-TLS/mbedtls/commit/027f84c69f4ef30c0693832a6c396ef19e563ca1

**What this PR does:** This PR applies the same security patch that was applied to the original repository to eliminate the vulnerability in the cloned code.

**References:**

* https://github.com/Mbed-TLS/mbedtls/commit/027f84c69f4ef30c0693832a6c396ef19e563ca1
* https://nvd.nist.gov/vuln/detail/CVE-2018-9988

Please review and merge this PR to ensure your repository is protected against this vulnerability.